### PR TITLE
Include role transitions in the tree when parsing.

### DIFF
--- a/src/ordering.c
+++ b/src/ordering.c
@@ -183,6 +183,8 @@ const char *get_section(const struct policy_node *node)
 		// The case of multiple source types is weird.  For now
 		// just using the first one seems fine.
 		return node->data.av_data->sources->string;
+	case NODE_RT_RULE:
+		return "_non_ordered";
 	case NODE_ROLE_ALLOW:
 		// This is not in the style guide. I normally see it grouped
 		// with declarations, but maybe a future ordering configuration

--- a/src/parse.y
+++ b/src/parse.y
@@ -401,7 +401,7 @@ range_transition:
 	;
 
 role_transition:
-	ROLE_TRANSITION string_list string_list STRING SEMICOLON { free_string_list($2); free_string_list($3); free($4); }
+	ROLE_TRANSITION string_list string_list STRING SEMICOLON { insert_role_transition(&cur, $2, $3, $4, yylineno); free($4); }
 	;
 
 interface_call:

--- a/src/parse_functions.c
+++ b/src/parse_functions.c
@@ -309,6 +309,38 @@ enum selint_error insert_type_transition(struct policy_node **cur,
 	return SELINT_SUCCESS;
 }
 
+enum selint_error insert_role_transition(struct policy_node **cur,
+                                         struct string_list *sources,
+                                         struct string_list *targets,
+                                         char *default_role,
+                                         unsigned int lineno)
+{
+	struct role_transition_data *rt_data =
+	        malloc(sizeof(struct role_transition_data));
+
+	rt_data->sources = sources;
+	rt_data->targets = targets;
+	rt_data->default_role = strdup(default_role);
+
+	union node_data nd;
+	nd.rt_data = rt_data;
+
+	enum selint_error ret = insert_policy_node_next(*cur,
+	                                                NODE_RT_RULE,
+	                                                nd,
+	                                                lineno);
+
+	if (ret != SELINT_SUCCESS) {
+		free_role_transition_data(rt_data);
+		return ret;
+	}
+
+	*cur = (*cur)->next;
+
+	return SELINT_SUCCESS;
+}
+
+
 enum selint_error insert_interface_call(struct policy_node **cur, const char *if_name,
                                         struct string_list *args,
                                         unsigned int lineno)

--- a/src/parse_functions.h
+++ b/src/parse_functions.h
@@ -137,7 +137,7 @@ enum selint_error insert_role_allow(struct policy_node **cur, const char *from_r
 * insert_type_transition
 * Add a type transition node at the next node in the tree, allocating all memory for it
 * cur (in, out) - The current spot in the tree.  Will be updated to point to
-*	the newly allocated av rule node
+*	the newly allocated type transition node
 * flavor (in) - The variety of type transition role.  The normal case is type_transition (TT_TT),
 * but other options include type_member (TT_TM), type_change (TT_TC) and range_transition (TT_RT)
 * sources (in) - (memory allocated by caller) The sources in the rule
@@ -155,6 +155,24 @@ enum selint_error insert_type_transition(struct policy_node **cur,
                                          struct string_list *targets,
                                          struct string_list *object_classes,
                                          const char *default_type, const char *name,
+                                         unsigned int lineno);
+
+/**********************************
+* insert_role_transition
+* Add a role transition node at the next node in the tree, allocating all memory for it
+* cur (in, out) - The current spot in the tree.  Will be updated to point to
+*	the newly allocated role transition node
+* sources (in) - (memory allocated by caller) The sources in the rule
+* targets (in) - (memory allocated by caller) the targets in the rule
+* default_role (in) - The role to transition to
+* lineno (in) - The line number of the rule
+*
+* Returns - SELINT error code
+**********************************/
+enum selint_error insert_role_transition(struct policy_node **cur,
+                                         struct string_list *sources,
+                                         struct string_list *targets,
+                                         char *default_role,
                                          unsigned int lineno);
 
 enum selint_error insert_interface_call(struct policy_node **cur, const char *if_name,

--- a/src/tree.c
+++ b/src/tree.c
@@ -126,6 +126,7 @@ struct string_list *get_types_in_node(const struct policy_node *node)
 	struct string_list *cur = NULL;
 	struct av_rule_data *av_data;
 	struct type_transition_data *tt_data;
+	struct role_transition_data *rt_data;
 	struct declaration_data *d_data;
 	struct if_call_data *ifc_data;
 	struct role_allow_data *ra_data;
@@ -166,6 +167,11 @@ struct string_list *get_types_in_node(const struct policy_node *node)
 			cur = ret = calloc(1, sizeof(struct string_list));
 			cur->string = strdup(tt_data->default_type);
 		}
+		break;
+
+	case NODE_RT_RULE:
+		rt_data = node->data.rt_data;
+		ret = copy_string_list(rt_data->targets);
 		break;
 
 	case NODE_DECL:
@@ -300,6 +306,9 @@ enum selint_error free_policy_node(struct policy_node *to_free)
 	case NODE_TT_RULE:
 		free_type_transition_data(to_free->data.tt_data);
 		break;
+	case NODE_RT_RULE:
+		free_role_transition_data(to_free->data.rt_data);
+		break;
 	case NODE_IF_CALL:
 		free_if_call_data(to_free->data.ic_data);
 		break;
@@ -382,6 +391,22 @@ enum selint_error free_type_transition_data(struct type_transition_data
 	free_string_list(to_free->object_classes);
 	free(to_free->default_type);
 	free(to_free->name);
+
+	free(to_free);
+
+	return SELINT_SUCCESS;
+}
+
+enum selint_error free_role_transition_data(struct role_transition_data
+                                            *to_free)
+{
+	if (to_free == NULL) {
+		return SELINT_BAD_ARG;
+	}
+
+	free_string_list(to_free->sources);
+	free_string_list(to_free->targets);
+	free(to_free->default_role);
 
 	free(to_free);
 

--- a/src/tree.h
+++ b/src/tree.h
@@ -26,6 +26,7 @@ enum node_flavor {
 	NODE_FC_FILE,
 	NODE_AV_RULE,
 	NODE_TT_RULE,
+	NODE_RT_RULE,
 	NODE_TM_RULE,
 	NODE_TC_RULE,
 	NODE_ROLE_ALLOW,
@@ -100,6 +101,12 @@ struct type_transition_data {
 	enum tt_flavor flavor;
 };
 
+struct role_transition_data {
+	struct string_list *sources;
+	struct string_list *targets;
+	char *default_role;
+};
+
 struct if_call_data {
 	char *name;
 	struct string_list *args;
@@ -144,6 +151,7 @@ union node_data {
 	struct av_rule_data *av_data;
 	struct role_allow_data *ra_data;
 	struct type_transition_data *tt_data;
+	struct role_transition_data *rt_data;
 	struct if_call_data *ic_data;
 	struct declaration_data *d_data;
 	struct fc_entry *fc_data;
@@ -195,6 +203,9 @@ enum selint_error free_av_rule_data(struct av_rule_data *to_free);
 enum selint_error free_ra_data(struct role_allow_data *to_free);
 
 enum selint_error free_type_transition_data(struct type_transition_data
+                                            *to_free);
+
+enum selint_error free_role_transition_data(struct role_transition_data
                                             *to_free);
 
 enum selint_error free_if_call_data(struct if_call_data *to_free);

--- a/tests/sample_policy_files/uncommon.te
+++ b/tests/sample_policy_files/uncommon.te
@@ -88,3 +88,5 @@ ifdef(`test',`
 ')
 
 foo_filter_template(synchronizer,synchronizer,`')
+
+role_transition foo_r bar_exec_t bar_r;


### PR DESCRIPTION
Also, handle them correctly for checks C-001, W-002 and W-003