### PR TITLE
Skip square brackets in regex parsing.

### DIFF
--- a/tests/check_fc_checks.c
+++ b/tests/check_fc_checks.c
@@ -328,6 +328,12 @@ START_TEST (test_check_file_context_regex) {
 	res = check_file_context_regex(data, node);
 	ck_assert_ptr_null(res);
 
+	free(entry->path);
+	entry->path = strdup("brackets\\.are[.s.kipped.]\\.");
+
+	res = check_file_context_regex(data, node);
+	ck_assert_ptr_null(res);
+
 	free(data->mod_name);
 	free(data);
 	free_policy_node(node);


### PR DESCRIPTION
In square brackets, regular expression special characters match themselves instead of their normal usage elsewhere, and should not be escaped.