### PR TITLE
Skip square brackets in regex parsing.

### DIFF
--- a/src/fc_checks.c
+++ b/src/fc_checks.c
@@ -75,9 +75,21 @@ struct check_result *check_file_context_regex(__attribute__((unused)) const stru
 	char prev = '\0';
 	int error = 0;
 
-	while (*path != '\0') {
+	while (cur != '\0') {
 		char next = *(path + 1);
 
+		if (cur == '[' && prev != '\\') {
+			// Fast forward through [ ] groups, because regex characters
+			// should not be escaped there
+			while (cur != '\0' &&
+			       (cur != ']' || prev == '\\')) {
+				next = *(path + 1);
+				prev = cur;
+				cur = next;
+				path++;
+			}
+			continue;
+		}
 		switch (cur) {
 		case '.':
 			// require that periods are either escaped or are one of ".*", ".+", or ".?"

--- a/tests/check_fc_checks.c
+++ b/tests/check_fc_checks.c
@@ -328,6 +328,24 @@ START_TEST (test_check_file_context_regex) {
 	res = check_file_context_regex(data, node);
 	ck_assert_ptr_null(res);
 
+	free(entry->path);
+	entry->path = strdup("brackets\\.are[.s.kipped.]\\.");
+
+	res = check_file_context_regex(data, node);
+	ck_assert_ptr_null(res);
+
+	free(entry->path);
+	entry->path = strdup("unclosed[bracket");
+
+	res = check_file_context_regex(data, node);
+	ck_assert_ptr_null(res);
+
+	free(entry->path);
+	entry->path = strdup("escaped[brackets\\]in.brackets]");
+
+	res = check_file_context_regex(data, node);
+	ck_assert_ptr_null(res);
+
 	free(data->mod_name);
 	free(data);
 	free_policy_node(node);


### PR DESCRIPTION
In square brackets, regular expression special characters match themselves instead of their normal usage elsewhere, and should not be escaped.