### PR TITLE
Add man page template to dist package

### DIFF
--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -16,9 +16,9 @@ SOURCES=selint.h2m
 
 if HAVE_HELP2MAN
 man1_MANS=$(MANPAGES)
-EXTRA_DIST=$(man1_MANS)
+EXTRA_DIST=$(man1_MANS) $(SOURCES)
 CLEANFILES=$(MANPAGES)
 
-selint.1: ../src/main.c
+selint.1: ../src/main.c $(SOURCES)
 	$(HELP2MAN) -n "Perform static source code analysis on SELinux policy source files" -N -i selint.h2m -o $@ ../src/selint
 endif


### PR DESCRIPTION
The template file for the man-page is missing in the release archive.
This causes problems once `make clean` is invoked, which deletes both, the template and the final man-page, so the man-page can no longer be generated.