### PR TITLE
Avoid duplicate definitions of global variables

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -30,7 +30,7 @@
 #include "selint_config.h"
 #include "startup.h"
 
-int yydebug = 0;
+extern int yydebug;
 
 extern int yylex_destroy(void);
 
@@ -87,6 +87,8 @@ int main(int argc, char **argv)
 
 	struct string_list *cl_e_cursor = NULL;
 	struct string_list *cl_d_cursor = NULL;
+
+	yydebug = 0;
 
 	while (1) {
 

--- a/tests/check_parsing.c
+++ b/tests/check_parsing.c
@@ -35,7 +35,7 @@ extern FILE * yyin;
 extern int yyparse(void);
 extern int yyrestart(FILE *input_file);
 struct policy_node *ast;
-struct policy_node *cur;
+extern struct policy_node *cur;
 extern const char *parsing_filename;
 
 START_TEST (test_parse_basic_te) {

--- a/tests/check_template.c
+++ b/tests/check_template.c
@@ -170,7 +170,7 @@ START_TEST (test_replace_m4_list_too_few_args) {
 END_TEST
 
 struct policy_node *ast;
-struct policy_node *cur;
+extern struct policy_node *cur;
 
 START_TEST (test_nested_template_declarations) {
 
@@ -180,7 +180,7 @@ START_TEST (test_nested_template_declarations) {
 
 	yyin = fopen(NESTED_IF_FILENAME, "r");
 	parsing_filename = "nested";
-	yyparse();
+	ck_assert_int_eq(0, yyparse());
 	fclose(yyin);
 
 	struct string_list *called_args = calloc(1,sizeof(struct string_list));


### PR DESCRIPTION
Comply with gcc-10, which defaults -fno-common.

Also add a missing check if yyparse succeeds in one unit test.