### PR TITLE
improve ordering

### DIFF
--- a/src/ordering.h
+++ b/src/ordering.h
@@ -20,11 +20,7 @@
 
 #include "selint_error.h"
 #include "tree.h"
-
-enum order_conf {
-	ORDER_REF,
-	ORDER_LAX
-};
+#include "check_hooks.h"
 
 enum order_difference_reason {
 	ORDER_EQUAL  =0,
@@ -79,6 +75,7 @@ struct order_node {
 };
 
 struct ordering_metadata {
+	const char *mod_name;
 	struct section_data *sections;
 	size_t order_node_len;
 	struct order_node nodes[];
@@ -90,6 +87,7 @@ struct ordering_metadata {
 * This function allocates memory for, but does not populate the
 * nodes[] array.  That will be populated on the next pass in the
 * calculate_longest_increasing_subsequence function.
+* data (in) - The metadata about the file being scanned
 * head (in) - Pointer to the file node at the top of the AST
 * for a file.
 *
@@ -97,7 +95,7 @@ struct ordering_metadata {
 * and all data except the nodesp[ array populated.  The caller is
 * responsible for freeing all memory.  Returns NULL on error
 **********************************/
-struct ordering_metadata *prepare_ordering_metadata(const struct policy_node *head);
+struct ordering_metadata *prepare_ordering_metadata(const struct check_data *data, const struct policy_node *head);
 
 /**********************************
 * Calculate the longest increasing subsequence in a given file
@@ -149,7 +147,7 @@ float get_avg_line_by_name(const char *section_name, struct section_data *sectio
 /**********************************
 * Get the subsection within the rules for a domain for a particular policy node
 **********************************/
-enum local_subsection get_local_subsection(const struct policy_node *node);
+enum local_subsection get_local_subsection(const char *mod_name, const struct policy_node *node);
 
 /**********************************
 * Compare two nodes according to the refpolicy ordering conventions

--- a/src/parse_functions.h
+++ b/src/parse_functions.h
@@ -39,6 +39,7 @@ void set_current_module_name(const char *mn);
 
 /**********************************
 * Return the name of the current module
+* This is only available during parsing
 **********************************/
 char *get_current_module_name(void);
 

--- a/src/selint_config.h
+++ b/src/selint_config.h
@@ -21,7 +21,11 @@
 #include "string_list.h"
 #include "tree.h"
 #include "maps.h"
-#include "ordering.h"
+
+enum order_conf {
+	ORDER_REF,
+	ORDER_LAX
+};
 
 struct config_check_data {
 	enum order_conf order_conf;

--- a/src/te_checks.c
+++ b/src/te_checks.c
@@ -34,7 +34,7 @@ struct check_result *check_te_order(const struct check_data *data,
 
 	switch (node->flavor) {
 	case NODE_TE_FILE:
-		order_data = prepare_ordering_metadata(node);
+		order_data = prepare_ordering_metadata(data, node);
 		order_node_arr_index = 0;
 		if (!order_data) {
 			return alloc_internal_error("Failed to initialize ordering for C-001");

--- a/tests/functional/end-to-end.bats
+++ b/tests/functional/end-to-end.bats
@@ -61,7 +61,7 @@ test_ordering() {
 			echo "Checking for $p"
 			count=$(echo ${output} | grep -o ${p} | wc -l)
 			[ "$count" -eq "1" ]
-		done < "${CHECK_DIR}/${FILENAME_PREFIX}.expect"
+		done < "${CHECK_DIR}/${FILENAME_PREFIX}.expect.${ORDER_CONF}"
 		local EXPECT_COUNT=$(cat ${CHECK_DIR}/${FILENAME_PREFIX}.expect.${ORDER_CONF} | wc -l)
 		count=$(echo ${output} | grep -o C-001 | wc -l)
 		echo "Expecting: ${EXPECT_COUNT}, got: $count"


### PR DESCRIPTION
 * ignore order of auditallow rules
 * ignore order of interfaces which are of type filetrans and transform
 * order calls to interfaces from own module as section own
 * treat foo, foo_t and foo_r as same raw section
 * accept order of sections bar_t followed by foo_t without any
   interfaces in between
 * print type of issued line
 * add _mountpoint suffix to transform interfaces
 * mark interfaces with associate av-rule always as transform interface
   independent from its name
 * mark interfaces with filetrans_add_pattern or _filetrans calls as
   filtrans interface
 * treat calls to interfaces from mcs and mls module as transform
   interface