### PR TITLE
Assume that system_u and object_r are declared if no config file is l…

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,8 @@
 # SELint Changelog
 
 ## Unreleased
-### Added
+### Added (general feature)
 - -S flag to print a summary of issue found following an analysis
-- Check S-003 for unneeded semicolons
 - --context flag to specify additional files to parse but not scan.
   This is primarily helpful if you want to only scan your modified files
   in a full source repository.  (If you are planning on loading your local
@@ -12,10 +11,19 @@
   don't need to use this option)
 - -F flag to return an error code on issues found
 
+### Added (checks)
+- S-003 for unneeded semicolons
+- E-006 for attribute/interface name clash
+
+### Changed
+- Turn C-001 off by default.
+- Assume the presence of system_u user and object_r role if no config is loaded.
+
 ### Fixed
 - Man page generation in distribution tarballs now works after make clean
 - documentation cleanup
 - Various parser fixes
+- Clean up of check C-001
 
 ## [1.0.2] - 2020-01-30
 ### Fixed

--- a/src/main.c
+++ b/src/main.c
@@ -262,6 +262,11 @@ int main(int argc, char **argv)
 		if (severity == '\0') {
 			severity = cfg_severity;
 		}
+	} else {
+		// If there is no config, we should assume the existance of normal users and
+		// roles that we wouldn't otherwise know about
+		insert_into_decl_map("system_u", "__assumed__", DECL_USER);
+		insert_into_decl_map("object_r", "__assumed__", DECL_ROLE);
 	}
 
 	struct string_list *config_check_id = config_disabled_checks;


### PR DESCRIPTION
…oaded.

If a config file is loaded, then the users and roles to be assumed are set via "assume_users" and "assume_roles".  If no config file is loaded, then selint doesn't know about these and reports issues E-003 and E-004 on every fc file line that mentions them.  Assuming normal names is a saner behavior in the lack of a config file that should help users get more helpful results