### PR TITLE
Exit and warn when using -E without any -e

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -279,6 +279,11 @@ int main(int argc, char **argv)
 		WARN_ON_INVALID_CHECK_ID(config_check_id->string, "enabled in config");
 		config_check_id = config_check_id->next;
 	}
+	
+	if (only_enabled && !cl_enabled_checks) {
+		printf("Error: no warning enabled!\n");
+		exit(EX_USAGE);
+	}
 
 	if (severity == '\0') {
 		severity = 'C';


### PR DESCRIPTION
Avoid the void usage of: `selint -sr -E E-001 policy_dir` (E-001 would be treated as dir not as check id)