### PR TITLE
RFC: Add check for multiple classes in allow rule

### DIFF
--- a/README
+++ b/README
@@ -134,6 +134,7 @@ CHECK IDS
 	C-001: Violation of refpolicy te file ordering conventions
 	C-004: Interface does not have documentation comment
 	C-005: Permissions in av rule or class declaration not ordered
+	C-006: Allow rule with multiple classes
 
 	S-001: Require block used instead of interface call
 	S-002: File context file labels with type not declared in module

--- a/src/check_hooks.h
+++ b/src/check_hooks.h
@@ -25,6 +25,7 @@ enum convention_ids {
 	C_ID_TE_ORDER       = 1,
 	C_ID_IF_COMMENT     = 4,
 	C_ID_UNORDERED_PERM = 5,
+	C_ID_MUL_CLS_ALLOW  = 6,
 	C_END
 };
 

--- a/src/runner.c
+++ b/src/runner.c
@@ -141,6 +141,10 @@ struct checks *register_checks(char level,
 			add_check(NODE_DECL, ck, "C-005",
 			          check_unordered_perms);
 		}
+		if (CHECK_ENABLED("C-006")) {
+			add_check(NODE_AV_RULE, ck, "C-006",
+			          check_multi_class_allow_rule);
+		}
 		// FALLTHRU
 	case 'S':
 		if (CHECK_ENABLED("S-001")) {

--- a/src/te_checks.c
+++ b/src/te_checks.c
@@ -114,6 +114,35 @@ struct check_result *check_unordered_perms(__attribute__((unused)) const struct 
 
 }
 
+struct check_result *check_multi_class_allow_rule(__attribute__((unused)) const struct check_data *data,
+                                                  const struct policy_node *node)
+{
+	// ignore non-allow rules
+	if (node->data.av_data->flavor != AV_RULE_ALLOW) {
+		return NULL;
+	}
+
+	const struct string_list *classes = node->data.av_data->object_classes;
+
+	if (!classes->next) {
+		return NULL;
+	}
+
+	const struct string_list *perms = node->data.av_data->perms;
+
+	// ignore rules with a single base permission
+	if (!perms->next) {
+		const char *suffix = strrchr(perms->string, '_');
+		if (!suffix ||
+		    (0 != strcmp(suffix, "_perms"))) {
+			return NULL;
+		}
+	}
+
+	return make_check_result('C', C_ID_MUL_CLS_ALLOW,
+				 "Allow rule with more than one class");
+}
+
 struct check_result *check_require_block(const struct check_data *data,
                                          const struct policy_node *node)
 {

--- a/src/te_checks.h
+++ b/src/te_checks.h
@@ -46,6 +46,16 @@ struct check_result *check_unordered_perms(const struct check_data *data,
                                            const struct policy_node *node);
 
 /*********************************************
+* Check for allow rule with multiple classes.
+* Called on NODE_AV_RULE nodes.
+* data - metadata about the file currently being scanned
+* node - the node to check
+* returns NULL if passed or check_result for issue C-006
+*********************************************/
+struct check_result *check_multi_class_allow_rule(const struct check_data *data,
+                                                  const struct policy_node *node);
+
+/*********************************************
 * Check for the presence of require blocks in TE files.
 * Interface calls are to be prefered.
 * Called on NODE_REQUIRE and NODE_GEN_REQ nodes.

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -114,6 +114,9 @@ FUNCTIONAL_TEST_FILES=functional/end-to-end.bats \
 			functional/policies/check_triggers/c04.if \
 			functional/policies/check_triggers/c05.if \
 			functional/policies/check_triggers/c05.te \
+			functional/policies/check_triggers/c06.1.te \
+			functional/policies/check_triggers/c06.2.te \
+			functional/policies/check_triggers/c06.3.te \
 			functional/policies/check_triggers/e02.fc \
 			functional/policies/check_triggers/e03e04e05.fc \
 			functional/policies/check_triggers/e06.te \

--- a/tests/functional/end-to-end.bats
+++ b/tests/functional/end-to-end.bats
@@ -92,6 +92,12 @@ test_one_check() {
 	test_one_check "C-005" "c05.if"
 }
 
+@test "C-006" {
+	test_one_check "C-006" "c06.1.te"
+	test_one_check "C-006" "c06.2.te"
+	test_one_check_expect "C-006" "c06.3.te" 0
+}
+
 @test "S-001" {
 	test_one_check "S-001" "s01.te"
 }

--- a/tests/functional/policies/check_triggers/c06.1.te
+++ b/tests/functional/policies/check_triggers/c06.1.te
@@ -1,0 +1,3 @@
+policy_module(c07, 1.0)
+
+allow source target:{ cls1 cls2 } some_perms;

--- a/tests/functional/policies/check_triggers/c06.2.te
+++ b/tests/functional/policies/check_triggers/c06.2.te
@@ -1,0 +1,3 @@
+policy_module(c07, 1.0)
+
+allow source target:{ cls1 cls2 } { perm1 perm2 };

--- a/tests/functional/policies/check_triggers/c06.3.te
+++ b/tests/functional/policies/check_triggers/c06.3.te
@@ -1,0 +1,3 @@
+policy_module(c07, 1.0)
+
+allow source target:{ cls1 cls2 } basicperm;


### PR DESCRIPTION
Findings in refpolicy:

```
init.te:        246: (C): Allow rule with more than one class (C-006)
    allow init_t init_path_unit_loc_type:{ dir file } { getattr watch };
bootloader.te:  162: (C): Allow rule with more than one class (C-006)
    allow bootloader_t bootloader_tmp_t:{ dir file } { relabelfrom relabelto };
courier.te:     140: (C): Allow rule with more than one class (C-006)
    allow courier_pop_t courier_tcpd_t:{ unix_stream_socket tcp_socket } rw_stream_socket_perms;
postfixpolicyd.te:40: (C): Allow rule with more than one class (C-006)
    allow postfix_policyd_t postfix_policyd_tmp_t:{ file sock_file } manage_file_perms;
xserver.te:     805: (C): Allow rule with more than one class (C-006)
    allow xserver_t xevent_type:{ x_event x_synthetic_event } { send receive };
xserver.te:     950: (C): Allow rule with more than one class (C-006)
    allow x_domain self:{ x_device x_pointer x_keyboard } { getattr setattr use read write getfocus setfocus bell force_cursor freeze grab manage list_property get_property set_property add remove create destroy };
xserver.te:    1015: (C): Allow rule with more than one class (C-006)
    allow x_domain xevent_type:{ x_event x_synthetic_event } { send receive };
xserver.te:    1032: (C): Allow rule with more than one class (C-006)
    allow xserver_unconfined_type xevent_type:{ x_event x_synthetic_event } { send receive };
domain.te:      159: (C): Allow rule with more than one class (C-006)
    allow unconfined_domain_type domain:{ socket_class_set socket key_socket } { create_stream_socket_perms lock relabelto name_bind map sendto recvfrom relabelfrom };
unconfined.if:   23: (C): Allow rule with more than one class (C-006)
    llow $1 self:{ capability cap_userns } { chown dac_override dac_read_search fowner fsetid kill setgid setuid setpcap linux_immutable net_bind_service net_broadcast net_admin net_raw ipc_lock ipc_owner sys_rawio sys_chroot sys_ptrace sys_pacct sys_admin sys_boot sys_nice sys_resource sys_time sys_tty_config mknod lease audit_write audit_control setfcap };
unconfined.if:   24: (C): Allow rule with more than one class (C-006)
    allow $1 self:{ capability2 cap2_userns } { syslog wake_alarm };
xserver.if:    1595: (C): Allow rule with more than one class (C-006)
    allow $1 xserver_t:{ x_device x_pointer x_keyboard } { getattr setattr use read write getfocus setfocus bell force_cursor freeze grab manage list_property get_property set_property add remove create destroy };
```