### PR TITLE
RFC: Add check for too many permissions in allow rule

### DIFF
--- a/README
+++ b/README
@@ -134,6 +134,7 @@ CHECK IDS
 	C-001: Violation of refpolicy te file ordering conventions
 	C-004: Interface does not have documentation comment
 	C-005: Permissions in av rule or class declaration not ordered
+	C-006: To many permissions in allow rule
 
 	S-001: Require block used instead of interface call
 	S-002: File context file labels with type not declared in module

--- a/src/check_hooks.h
+++ b/src/check_hooks.h
@@ -25,6 +25,7 @@ enum convention_ids {
 	C_ID_TE_ORDER       = 1,
 	C_ID_IF_COMMENT     = 4,
 	C_ID_UNORDERED_PERM = 5,
+	C_ID_TOO_MANY_PERMS = 6,
 	C_END
 };
 

--- a/src/runner.c
+++ b/src/runner.c
@@ -141,6 +141,10 @@ struct checks *register_checks(char level,
 			add_check(NODE_DECL, ck, "C-005",
 			          check_unordered_perms);
 		}
+		if (CHECK_ENABLED("C-006")) {
+			add_check(NODE_AV_RULE, ck, "C-006",
+			          check_too_many_perms_in_allow_rule);
+		}
 		// FALLTHRU
 	case 'S':
 		if (CHECK_ENABLED("S-001")) {

--- a/src/te_checks.h
+++ b/src/te_checks.h
@@ -46,6 +46,16 @@ struct check_result *check_unordered_perms(const struct check_data *data,
                                            const struct policy_node *node);
 
 /*********************************************
+* Check for too many permissions in av rules.
+* Called on NODE_AV_RULE nodes.
+* data - metadata about the file currently being scanned
+* node - the node to check
+* returns NULL if passed or check_result for issue C-006
+*********************************************/
+struct check_result *check_too_many_perms_in_allow_rule(const struct check_data *data,
+                                                        const struct policy_node *node);
+
+/*********************************************
 * Check for the presence of require blocks in TE files.
 * Interface calls are to be prefered.
 * Called on NODE_REQUIRE and NODE_GEN_REQ nodes.

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -114,6 +114,7 @@ FUNCTIONAL_TEST_FILES=functional/end-to-end.bats \
 			functional/policies/check_triggers/c04.if \
 			functional/policies/check_triggers/c05.if \
 			functional/policies/check_triggers/c05.te \
+			functional/policies/check_triggers/c06.te \
 			functional/policies/check_triggers/e02.fc \
 			functional/policies/check_triggers/e03e04e05.fc \
 			functional/policies/check_triggers/e06.te \

--- a/tests/functional/end-to-end.bats
+++ b/tests/functional/end-to-end.bats
@@ -92,6 +92,10 @@ test_one_check() {
 	test_one_check "C-005" "c05.if"
 }
 
+@test "C-006" {
+	test_one_check "C-006" "c06.te"
+}
+
 @test "S-001" {
 	test_one_check "S-001" "s01.te"
 }

--- a/tests/functional/policies/check_triggers/c06.te
+++ b/tests/functional/policies/check_triggers/c06.te
@@ -1,0 +1,3 @@
+policy_module(c06, 1.0)
+
+allow source target:cls { perm1 perm2 perm3 perm4 perm5 };


### PR DESCRIPTION
Has 166 findings in refpolicy:

```
systemd.te:     349: (C): Too many permissions (5) for class unix_dgram_socket in allow rule (use permission macro) (C-006)
systemd.te:    1249: (C): Too many permissions (5) for class netlink_kobject_uevent_socket in allow rule (use permission macro) (C-006)
logging.te:     530: (C): Too many permissions (5) for class netlink_audit_socket in allow rule (use permission macro) (C-006)
init.te:        242: (C): Too many permissions (5) for class bpf in allow rule (use permission macro) (C-006)
init.te:        273: (C): Too many permissions (5) for class unix_stream_socket in allow rule (use permission macro) (C-006)
init.te:        275: (C): Too many permissions (5) for class unix_stream_socket in allow rule (use permission macro) (C-006)
init.te:        583: (C): Too many permissions (15) for class unix_stream_socket in allow rule (use permission macro) (C-006)
init.te:        987: (C): Too many permissions (5) for class system in allow rule (use permission macro) (C-006)
init.te:       1413: (C): Too many permissions (6) for class socket_class_set in allow rule (use permission macro) (C-006)
rkhunter.te:     41: (C): Too many permissions (6) for class tcp_socket in allow rule (use permission macro) (C-006)
rkhunter.te:     43: (C): Too many permissions (6) for class udp_socket in allow rule (use permission macro) (C-006)
netutils.te:    110: (C): Too many permissions (8) for class rawip_socket in allow rule (use permission macro) (C-006)
netutils.te:    111: (C): Too many permissions (7) for class packet_socket in allow rule (use permission macro) (C-006)
virt.te:        464: (C): Too many permissions (5) for class unix_stream_socket in allow rule (use permission macro) (C-006)
networkmanager.te:60: (C): Too many permissions (6) for class alg_socket in allow rule (use permission macro) (C-006)
networkmanager.te:62: (C): Too many permissions (5) for class rawip_socket in allow rule (use permission macro) (C-006)
postgresql.te:  231: (C): Too many permissions (11) for class db_database in allow rule (use permission macro) (C-006)
postgresql.te:  237: (C): Too many permissions (9) for class db_schema in allow rule (use permission macro) (C-006)
postgresql.te:  241: (C): Too many permissions (11) for class db_table in allow rule (use permission macro) (C-006)
postgresql.te:  242: (C): Too many permissions (9) for class db_column in allow rule (use permission macro) (C-006)
postgresql.te:  243: (C): Too many permissions (7) for class db_tuple in allow rule (use permission macro) (C-006)
postgresql.te:  246: (C): Too many permissions (9) for class db_sequence in allow rule (use permission macro) (C-006)
postgresql.te:  249: (C): Too many permissions (7) for class db_view in allow rule (use permission macro) (C-006)
postgresql.te:  252: (C): Too many permissions (9) for class db_procedure in allow rule (use permission macro) (C-006)
postgresql.te:  255: (C): Too many permissions (10) for class db_blob in allow rule (use permission macro) (C-006)
postgresql.te:  426: (C): Too many permissions (6) for class db_table in allow rule (use permission macro) (C-006)
postgresql.te:  457: (C): Too many permissions (6) for class db_blob in allow rule (use permission macro) (C-006)
postgresql.te:  475: (C): Too many permissions (7) for class db_schema in allow rule (use permission macro) (C-006)
postgresql.te:  476: (C): Too many permissions (9) for class db_table in allow rule (use permission macro) (C-006)
postgresql.te:  477: (C): Too many permissions (7) for class db_column in allow rule (use permission macro) (C-006)
postgresql.te:  478: (C): Too many permissions (5) for class db_tuple in allow rule (use permission macro) (C-006)
postgresql.te:  479: (C): Too many permissions (7) for class db_sequence in allow rule (use permission macro) (C-006)
postgresql.te:  480: (C): Too many permissions (5) for class db_view in allow rule (use permission macro) (C-006)
postgresql.te:  481: (C): Too many permissions (7) for class db_procedure in allow rule (use permission macro) (C-006)
postgresql.te:  495: (C): Too many permissions (7) for class db_database in allow rule (use permission macro) (C-006)
postgresql.te:  497: (C): Too many permissions (9) for class db_schema in allow rule (use permission macro) (C-006)
postgresql.te:  501: (C): Too many permissions (7) for class db_table in allow rule (use permission macro) (C-006)
postgresql.te:  502: (C): Too many permissions (6) for class db_column in allow rule (use permission macro) (C-006)
postgresql.te:  503: (C): Too many permissions (7) for class db_tuple in allow rule (use permission macro) (C-006)
postgresql.te:  507: (C): Too many permissions (9) for class db_sequence in allow rule (use permission macro) (C-006)
postgresql.te:  511: (C): Too many permissions (7) for class db_view in allow rule (use permission macro) (C-006)
postgresql.te:  515: (C): Too many permissions (5) for class db_procedure in allow rule (use permission macro) (C-006)
postgresql.te:  520: (C): Too many permissions (7) for class db_schema in allow rule (use permission macro) (C-006)
postgresql.te:  521: (C): Too many permissions (9) for class db_table in allow rule (use permission macro) (C-006)
postgresql.te:  522: (C): Too many permissions (7) for class db_column in allow rule (use permission macro) (C-006)
postgresql.te:  523: (C): Too many permissions (5) for class db_tuple in allow rule (use permission macro) (C-006)
postgresql.te:  524: (C): Too many permissions (7) for class db_sequence in allow rule (use permission macro) (C-006)
postgresql.te:  525: (C): Too many permissions (5) for class db_view in allow rule (use permission macro) (C-006)
postgresql.te:  526: (C): Too many permissions (7) for class db_procedure in allow rule (use permission macro) (C-006)
postgresql.te:  528: (C): Too many permissions (7) for class db_language in allow rule (use permission macro) (C-006)
postgresql.te:  532: (C): Too many permissions (6) for class db_blob in allow rule (use permission macro) (C-006)
postgresql.te:  541: (C): Too many permissions (11) for class db_database in allow rule (use permission macro) (C-006)
postgresql.te:  543: (C): Too many permissions (9) for class db_schema in allow rule (use permission macro) (C-006)
postgresql.te:  545: (C): Too many permissions (11) for class db_table in allow rule (use permission macro) (C-006)
postgresql.te:  546: (C): Too many permissions (9) for class db_column in allow rule (use permission macro) (C-006)
postgresql.te:  547: (C): Too many permissions (7) for class db_tuple in allow rule (use permission macro) (C-006)
postgresql.te:  548: (C): Too many permissions (9) for class db_sequence in allow rule (use permission macro) (C-006)
postgresql.te:  549: (C): Too many permissions (7) for class db_view in allow rule (use permission macro) (C-006)
postgresql.te:  551: (C): Too many permissions (9) for class db_procedure in allow rule (use permission macro) (C-006)
postgresql.te:  552: (C): Too many permissions (8) for class db_procedure in allow rule (use permission macro) (C-006)
postgresql.te:  553: (C): Too many permissions (7) for class db_procedure in allow rule (use permission macro) (C-006)
postgresql.te:  555: (C): Too many permissions (7) for class db_language in allow rule (use permission macro) (C-006)
postgresql.te:  557: (C): Too many permissions (10) for class db_blob in allow rule (use permission macro) (C-006)
postgresql.te:  565: (C): Too many permissions (11) for class db_database in allow rule (use permission macro) (C-006)
postgresql.te:  567: (C): Too many permissions (9) for class db_schema in allow rule (use permission macro) (C-006)
postgresql.te:  578: (C): Too many permissions (11) for class db_table in allow rule (use permission macro) (C-006)
postgresql.te:  579: (C): Too many permissions (9) for class db_column in allow rule (use permission macro) (C-006)
postgresql.te:  580: (C): Too many permissions (7) for class db_tuple in allow rule (use permission macro) (C-006)
postgresql.te:  581: (C): Too many permissions (9) for class db_sequence in allow rule (use permission macro) (C-006)
postgresql.te:  582: (C): Too many permissions (7) for class db_view in allow rule (use permission macro) (C-006)
postgresql.te:  586: (C): Too many permissions (9) for class db_procedure in allow rule (use permission macro) (C-006)
postgresql.te:  587: (C): Too many permissions (8) for class db_procedure in allow rule (use permission macro) (C-006)
postgresql.te:  588: (C): Too many permissions (7) for class db_procedure in allow rule (use permission macro) (C-006)
postgresql.te:  590: (C): Too many permissions (7) for class db_language in allow rule (use permission macro) (C-006)
postgresql.te:  592: (C): Too many permissions (10) for class db_blob in allow rule (use permission macro) (C-006)
xserver.te:     791: (C): Too many permissions (6) for class x_server in allow rule (use permission macro) (C-006)
xserver.te:     792: (C): Too many permissions (19) for class x_drawable in allow rule (use permission macro) (C-006)
xserver.te:     793: (C): Too many permissions (8) for class x_screen in allow rule (use permission macro) (C-006)
xserver.te:     794: (C): Too many permissions (5) for class x_gc in allow rule (use permission macro) (C-006)
xserver.te:     795: (C): Too many permissions (10) for class x_colormap in allow rule (use permission macro) (C-006)
xserver.te:     796: (C): Too many permissions (7) for class x_property in allow rule (use permission macro) (C-006)
xserver.te:     798: (C): Too many permissions (7) for class x_cursor in allow rule (use permission macro) (C-006)
xserver.te:     800: (C): Too many permissions (19) for class x_device in allow rule (use permission macro) (C-006)
xserver.te:     801: (C): Too many permissions (19) for class x_pointer in allow rule (use permission macro) (C-006)
xserver.te:     802: (C): Too many permissions (19) for class x_keyboard in allow rule (use permission macro) (C-006)
xserver.te:     931: (C): Too many permissions (6) for class x_property in allow rule (use permission macro) (C-006)
xserver.te:     935: (C): Too many permissions (9) for class x_drawable in allow rule (use permission macro) (C-006)
xserver.te:     937: (C): Too many permissions (14) for class x_drawable in allow rule (use permission macro) (C-006)
xserver.te:     944: (C): Too many permissions (6) for class x_colormap in allow rule (use permission macro) (C-006)
xserver.te:     946: (C): Too many permissions (10) for class x_colormap in allow rule (use permission macro) (C-006)
xserver.te:     952: (C): Too many permissions (9) for class x_device in allow rule (use permission macro) (C-006)
xserver.te:     954: (C): Too many permissions (7) for class x_keyboard in allow rule (use permission macro) (C-006)
xserver.te:     956: (C): Too many permissions (10) for class x_pointer in allow rule (use permission macro) (C-006)
xserver.te:     984: (C): Too many permissions (7) for class x_cursor in allow rule (use permission macro) (C-006)
xserver.te:     986: (C): Too many permissions (5) for class x_gc in allow rule (use permission macro) (C-006)
xserver.te:    1001: (C): Too many permissions (6) for class x_server in allow rule (use permission macro) (C-006)
xserver.te:    1002: (C): Too many permissions (19) for class x_drawable in allow rule (use permission macro) (C-006)
xserver.te:    1003: (C): Too many permissions (8) for class x_screen in allow rule (use permission macro) (C-006)
xserver.te:    1004: (C): Too many permissions (5) for class x_gc in allow rule (use permission macro) (C-006)
xserver.te:    1005: (C): Too many permissions (10) for class x_colormap in allow rule (use permission macro) (C-006)
xserver.te:    1006: (C): Too many permissions (7) for class x_property in allow rule (use permission macro) (C-006)
xserver.te:    1008: (C): Too many permissions (7) for class x_cursor in allow rule (use permission macro) (C-006)
xserver.te:    1010: (C): Too many permissions (19) for class x_device in allow rule (use permission macro) (C-006)
xserver.te:    1011: (C): Too many permissions (19) for class x_pointer in allow rule (use permission macro) (C-006)
xserver.te:    1012: (C): Too many permissions (19) for class x_keyboard in allow rule (use permission macro) (C-006)
xserver.te:    1018: (C): Too many permissions (6) for class x_server in allow rule (use permission macro) (C-006)
xserver.te:    1019: (C): Too many permissions (19) for class x_drawable in allow rule (use permission macro) (C-006)
xserver.te:    1020: (C): Too many permissions (8) for class x_screen in allow rule (use permission macro) (C-006)
xserver.te:    1021: (C): Too many permissions (5) for class x_gc in allow rule (use permission macro) (C-006)
xserver.te:    1022: (C): Too many permissions (10) for class x_colormap in allow rule (use permission macro) (C-006)
xserver.te:    1023: (C): Too many permissions (7) for class x_property in allow rule (use permission macro) (C-006)
xserver.te:    1025: (C): Too many permissions (7) for class x_cursor in allow rule (use permission macro) (C-006)
xserver.te:    1027: (C): Too many permissions (19) for class x_device in allow rule (use permission macro) (C-006)
xserver.te:    1028: (C): Too many permissions (19) for class x_pointer in allow rule (use permission macro) (C-006)
xserver.te:    1029: (C): Too many permissions (19) for class x_keyboard in allow rule (use permission macro) (C-006)
selinux.te:      97: (C): Too many permissions (11) for class security in allow rule (use permission macro) (C-006)
files.te:       222: (C): Too many permissions (10) for class file in allow rule (use permission macro) (C-006)
files.te:       223: (C): Too many permissions (12) for class lnk_file in allow rule (use permission macro) (C-006)
files.te:       224: (C): Too many permissions (10) for class sock_file in allow rule (use permission macro) (C-006)
files.te:       225: (C): Too many permissions (10) for class fifo_file in allow rule (use permission macro) (C-006)
files.te:       226: (C): Too many permissions (10) for class blk_file in allow rule (use permission macro) (C-006)
files.te:       227: (C): Too many permissions (9) for class chr_file in allow rule (use permission macro) (C-006)
files.te:       228: (C): Too many permissions (16) for class dir in allow rule (use permission macro) (C-006)
files.te:       231: (C): Too many permissions (10) for class filesystem in allow rule (use permission macro) (C-006)
devices.te:     378: (C): Too many permissions (10) for class blk_file in allow rule (use permission macro) (C-006)
devices.te:     379: (C): Too many permissions (10) for class chr_file in allow rule (use permission macro) (C-006)
devices.te:     380: (C): Too many permissions (12) for class file in allow rule (use permission macro) (C-006)
filesystem.te:  324: (C): Too many permissions (10) for class filesystem in allow rule (use permission macro) (C-006)
filesystem.te:  329: (C): Too many permissions (12) for class file in allow rule (use permission macro) (C-006)
filesystem.te:  330: (C): Too many permissions (12) for class lnk_file in allow rule (use permission macro) (C-006)
filesystem.te:  331: (C): Too many permissions (10) for class sock_file in allow rule (use permission macro) (C-006)
filesystem.te:  332: (C): Too many permissions (10) for class fifo_file in allow rule (use permission macro) (C-006)
filesystem.te:  333: (C): Too many permissions (10) for class blk_file in allow rule (use permission macro) (C-006)
filesystem.te:  334: (C): Too many permissions (10) for class chr_file in allow rule (use permission macro) (C-006)
filesystem.te:  335: (C): Too many permissions (16) for class dir in allow rule (use permission macro) (C-006)
storage.te:      58: (C): Too many permissions (9) for class blk_file in allow rule (use permission macro) (C-006)
storage.te:      59: (C): Too many permissions (9) for class chr_file in allow rule (use permission macro) (C-006)
domain.te:      156: (C): Too many permissions (5) for class bpf in allow rule (use permission macro) (C-006)
domain.te:      167: (C): Too many permissions (5) for class netlink_audit_socket in allow rule (use permission macro) (C-006)
corenetwork.te:1994: (C): Too many permissions (5) for class packet in allow rule (use permission macro) (C-006)
kernel.te:      512: (C): Too many permissions (11) for class dir in allow rule (use permission macro) (C-006)
kernel.te:      513: (C): Too many permissions (12) for class lnk_file in allow rule (use permission macro) (C-006)
kernel.te:      514: (C): Too many permissions (10) for class file in allow rule (use permission macro) (C-006)
kernel.te:      516: (C): Too many permissions (11) for class dir in allow rule (use permission macro) (C-006)
kernel.te:      517: (C): Too many permissions (10) for class file in allow rule (use permission macro) (C-006)
kernel.te:      519: (C): Too many permissions (14) for class system in allow rule (use permission macro) (C-006)
kernel.te:      521: (C): Too many permissions (10) for class file in allow rule (use permission macro) (C-006)
kernel.te:      522: (C): Too many permissions (12) for class lnk_file in allow rule (use permission macro) (C-006)
kernel.te:      523: (C): Too many permissions (10) for class sock_file in allow rule (use permission macro) (C-006)
kernel.te:      524: (C): Too many permissions (10) for class fifo_file in allow rule (use permission macro) (C-006)
kernel.te:      525: (C): Too many permissions (10) for class blk_file in allow rule (use permission macro) (C-006)
kernel.te:      526: (C): Too many permissions (9) for class chr_file in allow rule (use permission macro) (C-006)
kernel.te:      527: (C): Too many permissions (16) for class dir in allow rule (use permission macro) (C-006)
kernel.te:      528: (C): Too many permissions (10) for class filesystem in allow rule (use permission macro) (C-006)
kernel.te:      530: (C): Too many permissions (5) for class packet in allow rule (use permission macro) (C-006)
unconfined.if:   34: (C): Too many permissions (10) for class nscd in allow rule (use permission macro) (C-006)
unconfined.if:   36: (C): Too many permissions (5) for class passwd in allow rule (use permission macro) (C-006)
nscd.if:        146: (C): Too many permissions (6) for class nscd in allow rule (use permission macro) (C-006)
nscd.if:        229: (C): Too many permissions (10) for class nscd in allow rule (use permission macro) (C-006)
postgresql.if:   71: (C): Too many permissions (6) for class db_table in allow rule (use permission macro) (C-006)
postgresql.if:   88: (C): Too many permissions (8) for class db_blob in allow rule (use permission macro) (C-006)
postgresql.if:  492: (C): Too many permissions (8) for class db_blob in allow rule (use permission macro) (C-006)
postgresql.if:  502: (C): Too many permissions (6) for class db_table in allow rule (use permission macro) (C-006)
postfix.if:     262: (C): Too many permissions (6) for class fifo_file in allow rule (use permission macro) (C-006)
files.if:      7099: (C): Too many permissions (9) for class dir in allow rule (use permission macro) (C-006)
files.if:      7112: (C): Too many permissions (7) for class dir in allow rule (use permission macro) (C-006)
```