### PR TITLE
Allow selint-disable comment after declaration in require block

### DIFF
--- a/src/parse.y
+++ b/src/parse.y
@@ -469,6 +469,12 @@ require_lines:
 	;
 
 require_line:
+	require_bare
+	|
+	require_bare SELINT_COMMAND { save_command(cur, $2); free($2); }
+	;
+
+require_bare:
 	TYPE comma_string_list SEMICOLON {
 		const struct string_list *iter = $2;
 		for (iter = $2; iter; iter = iter->next) insert_declaration(&cur, DECL_TYPE, iter->string, NULL, yylineno);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -184,6 +184,7 @@ FUNCTIONAL_TEST_FILES=functional/end-to-end.bats \
 			functional/policies/misc/disable.if \
 			functional/policies/misc/disable_multiple_other.te \
 			functional/policies/misc/disable_multiple.te \
+			functional/policies/misc/disable_require_decl.if \
 			functional/policies/misc/disable_require_start.te \
 			functional/policies/misc/disable.te \
 			functional/policies/misc/needs_context.te \

--- a/tests/functional/end-to-end.bats
+++ b/tests/functional/end-to-end.bats
@@ -272,6 +272,10 @@ test_one_check() {
 	run ${SELINT_PATH} -F -c configs/default.conf -d S-008 policies/misc/disable_require_start.*
 	[ "$status" -eq 0 ]
 	[ "$output" == "" ]
+
+	run ${SELINT_PATH} -F -c configs/default.conf policies/misc/disable_require_decl.*
+	[ "$status" -eq 0 ]
+	[ "$output" == "" ]
 }
 
 @test "nonexistent file" {

--- a/tests/functional/policies/misc/disable_require_decl.if
+++ b/tests/functional/policies/misc/disable_require_decl.if
@@ -1,0 +1,6 @@
+#comment
+interface(`disable_require_decl_if',`
+	gen_require(`
+		type foo_t; #selint-disable:W-003
+	')
+')


### PR DESCRIPTION
Fixes: 3f83758c1825c1e720867e18ab97ee18ef0eadf9 ("Separate grammar for real declarations and require content")