### PR TITLE
Skip S-002 checks on probably build generated filecontexts

### DIFF
--- a/selint.conf
+++ b/selint.conf
@@ -50,4 +50,5 @@ ordering_rules = "refpolicy-lax"
 # Currently the following checks are going to be disabled on build generated
 # files:
 #     S-002: base.fc, all_mods.fc, $MODNAME.mod.fc
+# If unset, this defaults to true.
 #skip_checking_generated_fcs = true

--- a/selint.conf
+++ b/selint.conf
@@ -43,3 +43,11 @@ assume_roles = { object_r }
 # - refpolicy-lax: (default) Similar to refpolicy, but ignore interface
 #   and block ordering requirements.
 ordering_rules = "refpolicy-lax"
+
+# Whether to ignore known false-positives on generated policy files.
+# In recursive mode SELint checks all files with known endings, regardless
+# if they are source or build generated files, like base.fc .
+# Currently the following checks are going to be disabled on build generated
+# files:
+#     S-002: base.fc, all_mods.fc, $MODNAME.mod.fc
+#skip_checking_generated_fcs = true

--- a/src/selint_config.h
+++ b/src/selint_config.h
@@ -17,6 +17,8 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
+#include <stdbool.h>
+
 #include "selint_error.h"
 #include "string_list.h"
 #include "tree.h"
@@ -29,6 +31,7 @@ enum order_conf {
 
 struct config_check_data {
 	enum order_conf order_conf;
+	bool skip_checking_generated_fcs;
 };
 
 /*******************************************************************

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -277,7 +277,7 @@ check_check_hooks_SOURCES = check_check_hooks.c ${CHECK_HOOKS_HEADS}
 check_check_hooks_LDADD = @CHECK_LIBS@ $(sort ${CHECK_HOOKS_OBJS})
 
 check_fc_checks_SOURCES = check_fc_checks.c ${FC_CHECKS_HEADS} ${CHECK_HOOKS_HEADS} ${MAPS_HEADS}
-check_fc_checks_LDADD = @CHECK_LIBS@ $(sort ${FC_CHECKS_OBJS} ${CHECK_HOOKS_OBJS} ${MAPS_OBJS})
+check_fc_checks_LDADD = @CHECK_LIBS@ $(sort ${FC_CHECKS_OBJS} ${CHECK_HOOKS_OBJS} ${MAPS_OBJS} ${UTIL_OBJS})
 
 check_if_checks_SOURCES = check_if_checks.c test_utils.c ${IF_CHECKS_HEADS} ${CHECK_HOOKS_HEADS} ${MAPS_HEADS} ${TEST_UTILS_HEADS}
 check_if_checks_LDADD = @CHECK_LIBS@ $(sort ${IF_CHECKS_OBJS} ${CHECK_HOOKS_OBJS} ${MAPS_OBJS} ${TEST_UTILS_OBJS})

--- a/tests/check_fc_checks.c
+++ b/tests/check_fc_checks.c
@@ -94,8 +94,11 @@ START_TEST (test_check_file_context_types_in_mod) {
 
 	struct check_data *data = malloc(sizeof(struct check_data));
 
+	data->filename = strdup("foo");
 	data->mod_name = strdup("foo");
 	data->flavor = FILE_FC_FILE;
+	struct config_check_data cfg = { ORDER_LAX, true };
+	data->config_check_data = &cfg;
 
 	struct policy_node *node = malloc(sizeof(struct policy_node));
 	memset(node, 0, sizeof(struct policy_node));
@@ -136,6 +139,7 @@ START_TEST (test_check_file_context_types_in_mod) {
 
 	free_all_maps();
 	free(data->mod_name);
+	free(data->filename);
 	free(data);
 	free_policy_node(node);
 
@@ -269,6 +273,7 @@ START_TEST (test_fc_checks_handle_null_context_fields) {
 
 	struct check_data *data = malloc(sizeof(struct check_data));
 
+	data->filename = strdup("foo");
 	data->mod_name = strdup("foo");
 	data->flavor = FILE_FC_FILE;
 
@@ -287,6 +292,7 @@ START_TEST (test_fc_checks_handle_null_context_fields) {
 	ck_assert_ptr_null(check_file_context_roles(data, node));
 	ck_assert_ptr_null(check_file_context_users(data, node));
 
+	free(data->filename);
 	free(data->mod_name);
 	free(data);
 


### PR DESCRIPTION
When running SELint on a already build policy structure,
S-002 triggers on the files base.fc, all_mods.fc and $MODULENAME.mod.fc