### PR TITLE
Add check for mismatch between class and permission macro

### DIFF
--- a/README
+++ b/README
@@ -151,6 +151,7 @@ CHECK IDS
 	S-006: Bare module statement
 	S-007: Call to gen_context omits mls component
 	S-008: Unquoted gen_require block
+	S-009: Permission macro suffix does not match class name
 
 	W-001: Type referenced without explicit declaration
 	W-002: Type, attribute or role used but not listed in require block in interface

--- a/src/check_hooks.h
+++ b/src/check_hooks.h
@@ -37,6 +37,7 @@ enum style_ids {
 	S_ID_BARE_MODULE    = 6,
 	S_ID_MISSING_RANGE  = 7,
 	S_ID_UNQUOTE_GENREQ = 8,
+	S_ID_PERM_SUFFIX    = 9,
 	S_END
 };
 

--- a/src/runner.c
+++ b/src/runner.c
@@ -177,6 +177,10 @@ struct checks *register_checks(char level,
 			add_check(NODE_GEN_REQ, ck, "S-008",
 			          check_unquoted_gen_require_block);
 		}
+		if (CHECK_ENABLED("S-009")) {
+			add_check(NODE_AV_RULE, ck, "S-009",
+			          check_perm_macro_class_mismatch);
+		}
 		// FALLTHRU
 	case 'W':
 		if (CHECK_ENABLED("W-001")) {

--- a/src/te_checks.h
+++ b/src/te_checks.h
@@ -77,6 +77,16 @@ struct check_result *check_bare_module_statement(const struct check_data *data,
                                                  const struct policy_node *node);
 
 /*********************************************
+* Check for name mismatch between permission macro and class name.
+* Called on NODE_AV_RULE nodes.
+* data - metadata about the file currently being scanned
+* node - the node to check
+* returns NULL if passed or check_result for issue S-009
+*********************************************/
+struct check_result *check_perm_macro_class_mismatch(const struct check_data *data,
+                                                     const struct policy_node *node);
+
+/*********************************************
 * Check for references to types in te files without an explicit declaration.
 * We don't check types in .if or .fc files because those are similar issues
 * handled by W-002 and E-005 respectively.

--- a/src/util.c
+++ b/src/util.c
@@ -16,6 +16,7 @@
 
 #include <stdio.h>
 #include <stdarg.h>
+#include <string.h>
 
 #include "util.h"
 
@@ -34,4 +35,13 @@ void print_if_verbose(const char *format, ...)
 	vprintf(format, args);
 
 	va_end(args);
+}
+
+bool ends_with(const char *str, size_t str_len, const char *suffix, size_t suffix_len)
+{
+	if (str_len < suffix_len) {
+		return 0;
+	}
+
+	return (0 == strncmp(str + str_len - suffix_len, suffix, suffix_len));
 }

--- a/src/util.h
+++ b/src/util.h
@@ -17,7 +17,19 @@
 #ifndef UTIL_H
 #define UTIL_H
 
+#include <stdbool.h>
+
 __attribute__((format(printf,1,2)))
 void print_if_verbose(const char *format, ...);
+
+/****************************************************
+* Checks whether a string ends with a suffix.
+* str - The string to check.
+* str_len - The length of the string to check.
+* suffix - The suffix to check against.
+* suffix_len - The lenght of the suffix to check against.
+* Returns true if the string ends with the given suffi, else false.
+****************************************************/
+bool ends_with(const char *str, size_t str_len, const char *suffix, size_t suffix_len);
 
 #endif

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -129,6 +129,8 @@ FUNCTIONAL_TEST_FILES=functional/end-to-end.bats \
 			functional/policies/check_triggers/s06.te \
 			functional/policies/check_triggers/s07.fc \
 			functional/policies/check_triggers/s08.if \
+			functional/policies/check_triggers/s09.pass.te \
+			functional/policies/check_triggers/s09.warn.te \
 			functional/policies/check_triggers/w01_other.te \
 			functional/policies/check_triggers/w01.te \
 			functional/policies/check_triggers/w02.if \
@@ -235,7 +237,7 @@ FC_CHECKS_OBJS=$(top_builddir)/src/fc_checks.o ${CHECK_HOOKS_OBJS}
 IF_CHECKS_HEADS=$(top_builddir)/src/if_checks.h ${CHECK_HOOKS_HEADS}
 IF_CHECKS_OBJS=$(top_builddir)/src/if_checks.o ${CHECK_HOOKS_OBJS}
 TE_CHECKS_HEADS=$(top_builddir)/src/te_checks.h ${CHECK_HOOKS_HEADS}
-TE_CHECKS_OBJS=$(top_builddir)/src/te_checks.o ${CHECK_HOOKS_OBJS} $(top_builddir)/src/ordering.o
+TE_CHECKS_OBJS=$(top_builddir)/src/te_checks.o ${CHECK_HOOKS_OBJS} $(top_builddir)/src/ordering.o ${UTIL_OBJS}
 RUNNER_HEADS=$(top_builddir)/src/runner.h ${SELINT_ERROR_HEADS} ${CHECK_HOOKS_HEADS} ${PARSE_FUNCTIONS_HEADS} ${FILE_LIST_HEADS}
 RUNNER_OBJS=$(top_builddir)/src/runner.o ${CHECK_HOOKS_OBJS} ${PARSE_FUNCTIONS_OBJS} ${FILE_LIST_OBJS} ${FC_CHECKS_OBJS} ${IF_CHECKS_OBJS} ${TE_CHECKS_OBJS} ${PARSE_FC_OBJS} ${UTIL_OBJS} ${STARTUP_OBJS} ${PARSE_OBJS}
 ORDERING_HEADS=$(top_builddir)/src/ordering.h ${SELINT_ERROR_HEADS} ${TREE_HEADS}

--- a/tests/functional/end-to-end.bats
+++ b/tests/functional/end-to-end.bats
@@ -124,6 +124,11 @@ test_one_check() {
 	test_one_check "S-008" "s08.if"
 }
 
+@test "S-009" {
+	test_one_check_expect "S-009" "s09.pass.te" 0
+	test_one_check_expect "S-009" "s09.warn.te" 4
+}
+
 @test "W-001" {
 	test_one_check "W-001" "w01*"
 }

--- a/tests/functional/policies/check_triggers/s09.pass.te
+++ b/tests/functional/policies/check_triggers/s09.pass.te
@@ -1,0 +1,17 @@
+policy_module(s09, 1.0)
+
+allow source target:foo some_foo_perms;
+
+allow source target:file write_file_perms;
+
+allow source target:fifo_file write_fifo_file_perms;
+
+allow source target:netlink_something_socket some_netlink_socket_perms;
+
+allow source target:netlink_something_socket some_socket_perms;
+
+allow source target:something_socket some_socket_perms;
+
+allow source target:chr_file rw_term_perms;
+
+allow source target:process signal_perms;

--- a/tests/functional/policies/check_triggers/s09.warn.te
+++ b/tests/functional/policies/check_triggers/s09.warn.te
@@ -1,0 +1,9 @@
+policy_module(s09, 1.0)
+
+allow source target:foo some_bar_perms;
+
+allow source target:file write_lnk_file_perms;
+
+allow source target:something_socket some_netlink_socket_perms;
+
+allow source target:blk_file rw_term_perms;


### PR DESCRIPTION
Refpolicy findings:

```
uml.te:              50: (S): Permission macro rw_file_perms does not match class chr_file (S-009)
seunshare.te:        21: (S): Permission macro rw_file_perms does not match class fifo_file (S-009)
evolution.te:        94: (S): Permission macro rw_file_perms does not match class fifo_file (S-009)
games.te:            96: (S): Permission macro rw_file_perms does not match class fifo_file (S-009)
selinuxutil.te:     407: (S): Permission macro rw_file_perms does not match class fifo_file (S-009)
selinuxutil.te:     575: (S): Permission macro rw_file_perms does not match class fifo_file (S-009)
init.te:            153: (S): Permission macro manage_lnk_file_perms does not match class file (S-009)
init.te:            585: (S): Permission macro rw_file_perms does not match class fifo_file (S-009)
authlogin.te:       170: (S): Permission macro rw_file_perms does not match class fifo_file (S-009)
hotplug.te:          30: (S): Permission macro rw_file_perms does not match class fifo_file (S-009)
bacula.te:          133: (S): Permission macro create_socket_perms does not match class dgram_socket_class_set (S-009)
ssh.te:             186: (S): Permission macro rw_file_perms does not match class fifo_file (S-009)
apache.te:         1123: (S): Permission macro rw_file_perms does not match class fifo_file (S-009)
virt.te:           1081: (S): Permission macro manage_file_perms does not match class fifo_file (S-009)
condor.te:          202: (S): Permission macro manage_file_perms does not match class dir (S-009)
munin.te:           318: (S): Permission macro create_sem_perms does not match class shm (S-009)
zosremote.te:        22: (S): Permission macro rw_file_perms does not match class fifo_file (S-009)
mon.te:             113: (S): Permission macro rw_file_perms does not match class fifo_file (S-009)
mon.te:             160: (S): Permission macro rw_file_perms does not match class fifo_file (S-009)
apcupsd.te:          37: (S): Permission macro rw_file_perms does not match class fifo_file (S-009)
dirmngr.te:          39: (S): Permission macro rw_file_perms does not match class fifo_file (S-009)
domain.te:          174: (S): Permission macro rw_file_perms does not match class fifo_file (S-009)
qemu.if:             32: (S): Permission macro rw_file_perms does not match class fifo_file (S-009)
udev.if:            292: (S): Permission macro relabelto_file_perms does not match class lnk_file (S-009)
userdomain.if:     2610: (S): Permission macro manage_file_perms does not match class lnk_file (S-009)
userdomain.if:     3492: (S): Permission macro delete_lnk_file_perms does not match class fifo_file (S-009)
userdomain.if:     3530: (S): Permission macro delete_sock_file_perms does not match class file (S-009)
userdomain.if:     3971: (S): Permission macro rw_file_perms does not match class fifo_file (S-009)
userdomain.if:     3994: (S): Permission macro rw_file_perms does not match class fifo_file (S-009)
userdomain.if:     4017: (S): Permission macro rw_file_perms does not match class fifo_file (S-009)
userdomain.if:     4040: (S): Permission macro rw_file_perms does not match class fifo_file (S-009)
userdomain.if:     4137: (S): Permission macro rw_file_perms does not match class fifo_file (S-009)
userdomain.if:     4160: (S): Permission macro rw_file_perms does not match class fifo_file (S-009)
userdomain.if:     4280: (S): Permission macro rw_file_perms does not match class chr_file (S-009)
userdomain.if:     4372: (S): Permission macro rw_file_perms does not match class chr_file (S-009)
selinuxutil.if:     356: (S): Permission macro rw_file_perms does not match class fifo_file (S-009)
selinuxutil.if:     384: (S): Permission macro rw_file_perms does not match class fifo_file (S-009)
unconfined.if:      200: (S): Permission macro rw_file_perms does not match class fifo_file (S-009)
unconfined.if:      421: (S): Permission macro rw_file_perms does not match class fifo_file (S-009)
su.if:               58: (S): Permission macro rw_file_perms does not match class fifo_file (S-009)
su.if:              167: (S): Permission macro rw_file_perms does not match class fifo_file (S-009)
portage.if:         203: (S): Permission macro create_file_perms does not match class sock_file (S-009)
apt.if:             136: (S): Permission macro rw_file_perms does not match class fifo_file (S-009)
dpkg.if:            103: (S): Permission macro rw_file_perms does not match class fifo_file (S-009)
dpkg.if:            123: (S): Permission macro rw_file_perms does not match class fifo_file (S-009)
dpkg.if:            216: (S): Permission macro rw_inherited_file_perms does not match class fifo_file (S-009)
ssh.if:             354: (S): Permission macro rw_file_perms does not match class fifo_file (S-009)
ssh.if:             408: (S): Permission macro rw_file_perms does not match class fifo_file (S-009)
sysadm.if:           79: (S): Permission macro rw_file_perms does not match class fifo_file (S-009)
sysadm.if:          100: (S): Permission macro rw_file_perms does not match class fifo_file (S-009)
sysadm.if:          123: (S): Permission macro rw_file_perms does not match class fifo_file (S-009)
sysadm.if:          158: (S): Permission macro rw_file_perms does not match class fifo_file (S-009)
sysadm.if:          192: (S): Permission macro rw_file_perms does not match class fifo_file (S-009)
storage.if:         422: (S): Permission macro rw_file_perms does not match class chr_file (S-009)
storage.if:         441: (S): Permission macro rw_file_perms does not match class chr_file (S-009)
storage.if:         570: (S): Permission macro rw_file_perms does not match class chr_file (S-009)
terminal.if:        190: (S): Permission macro rw_file_perms does not match class chr_file (S-009)
terminal.if:        824: (S): Permission macro rw_file_perms does not match class chr_file (S-009)
devices.if:         715: (S): Permission macro rw_chr_file_perms does not match class blk_file (S-009)
devices.if:        2716: (S): Permission macro rw_file_perms does not match class chr_file (S-009)
devices.if:        3089: (S): Permission macro rw_file_perms does not match class chr_file (S-009)
Found the following issue counts:
S-009: 61
```

Closes: #53