### PR TITLE
RFC: Make the --context flag imply source mode.  If a user has supplied co…

### DIFF
--- a/README
+++ b/README
@@ -48,7 +48,7 @@ OPTIONS
 	--context=CONTEXT_PATH
 		Also parse any .te or .if files found in CONTEXT_PATH and load symbols
 		associated with them for use when checking the policy files to be analyzed.
-		No checks are run on these files.
+		No checks are run on these files. Implies -s.
 
 	--debug-parser
 		Enable debug ouput for the internal policy parser.

--- a/src/main.c
+++ b/src/main.c
@@ -58,6 +58,7 @@ static void usage(void)
 		"      --context=CONTEXT_PATH\tRecursively scan CONTEXT_PATH to find additional te and if\n"\
 		"\t\t\t\tfiles to parse, but not scan.  SELint will assume the scanned policy files\n"\
 		"\t\t\t\tare intended to be compiled together with the context files.\n"\
+		"\t\t\t\tare intended to be compiled together with the context files.  Implies -s.\n"\
 		"      --debug-parser\t\tEnable debug ouput for the internal policy parser.\n"\
 		"\t\t\t\tVery noisy, useful to debug parsing failures.\n"\
 		"  -d, --disable=CHECKID\t\tDisable check with the given ID.\n"\
@@ -163,6 +164,8 @@ int main(int argc, char **argv)
 		case CONTEXT_ID:
 			// Specify a path for context files
 			context_path = optarg;
+			// Don't parse system devel policies if a context is given
+			source_flag = 1;
 			break;
 
 		case COLOR_ID:


### PR DESCRIPTION
…ntext files, they presumably no longer want to use system devel headers as the context.

@cgzones @stevedlawrence What are your thoughts about this?

I can't really think of a scenario where someone using --context wants to also scan the system development headers.  Of course, full source mode is overkill for that, so an alternative would be to only disable the development header loading if --context is specified, but it seems simpler and more understandable to me to just go to full source mode in this scenario rather than having a partial source mode sort of scenario.

For reference, the differences between source and normal mode right now are:
- Normal loads /usr/share/selinux/devel headers
- Source loads a modules.conf file for use with W-005 (normal mode silently doesn't support W-005 because I can't find a way to get this information from the system without root)
- enable_source and enable_normal config options are changed based on source or normal
- Some output messages

I could definitely see a user being surprised/confused by the third one in particular.  And I don't like a proliferation of flags implying other flags, but loading devel headers when --context is specified definitely seems wrong, and as I said above, just going to full source mode seems like a much cleaner solution in general.

What are your thoughts?