### PR TITLE
Fix bug where ifdefs inside require blocks didn't parse correctly.

### DIFF
--- a/src/parse.y
+++ b/src/parse.y
@@ -512,6 +512,12 @@ require_bare:
 	|
 	CLASS STRING string_list SEMICOLON { insert_declaration(&cur, DECL_CLASS, $2, $3, yylineno); free($2); }
 	|
+	if_or_ifn OPEN_PAREN BACKTICK STRING SINGLE_QUOTE COMMA BACKTICK { begin_ifdef(&cur, yylineno); }
+	require_lines SINGLE_QUOTE CLOSE_PAREN { end_ifdef(&cur); free($4); }
+	|
+	if_or_ifn OPEN_PAREN BACKTICK STRING SINGLE_QUOTE COMMA { begin_ifdef(&cur, yylineno); }
+	require_lines CLOSE_PAREN { end_ifdef(&cur); free($4); }
+	|
 	COMMENT
 	;
 

--- a/tests/functional/policies/misc/nesting.if
+++ b/tests/functional/policies/misc/nesting.if
@@ -1,7 +1,4 @@
-# Currently, ifdefs are discarded by the parser so this works fine with W-002
-# But if we ever save them and the gen_require becomes a child of the ifdef in
-# the tree, then this will break.  W-002 assumes that the gen_require is at
-# the top level.
+# Needed for W-002 to function correctly
 interface(`test_nesting',`
 	ifdef(`var',`
 		gen_require(`
@@ -9,4 +6,14 @@ interface(`test_nesting',`
 		')
 	')
 	append_files_pattern($1, foo_log_t, foo_data_t)
+')
+
+interface(`test_nesting_other_way',`
+	gen_require(`
+		type foo_log_t;
+		ifdef(`var',`
+			attribute foo_log;
+		')
+	')
+	append_files_pattern($1, foo_log, foo_log_t)
 ')


### PR DESCRIPTION
IE:

gen_require(`
	ifdef(`foo',`
		type foo_t;
	')
')