### PR TITLE
Return const pointers from maps lookup functions

### DIFF
--- a/src/fc_checks.c
+++ b/src/fc_checks.c
@@ -38,7 +38,7 @@ struct check_result *check_file_context_types_in_mod(const struct check_data
 
 	SETUP_FOR_FC_CHECK(node)
 
-	char *type_decl_mod_name = look_up_in_decl_map(entry->context->type,
+	const char *type_decl_mod_name = look_up_in_decl_map(entry->context->type,
 	                                               DECL_TYPE);
 
 	if (!type_decl_mod_name) {
@@ -162,7 +162,7 @@ struct check_result *check_file_context_users(__attribute__((unused)) const stru
 
 	SETUP_FOR_FC_CHECK(node)
 
-	char *user_decl_filename = look_up_in_decl_map(entry->context->user,
+	const char *user_decl_filename = look_up_in_decl_map(entry->context->user,
 	                                               DECL_USER);
 
 	if (!user_decl_filename) {
@@ -180,7 +180,7 @@ struct check_result *check_file_context_roles(__attribute__((unused)) const stru
 
 	SETUP_FOR_FC_CHECK(node)
 
-	char *role_decl_filename = look_up_in_decl_map(entry->context->role,
+	const char *role_decl_filename = look_up_in_decl_map(entry->context->role,
 	                                               DECL_ROLE);
 
 	if (!role_decl_filename) {
@@ -200,7 +200,7 @@ struct check_result *check_file_context_types_exist(__attribute__((unused)) cons
 
 	SETUP_FOR_FC_CHECK(node)
 
-	char *type_decl_filename = look_up_in_decl_map(entry->context->type,
+	const char *type_decl_filename = look_up_in_decl_map(entry->context->type,
 	                                               DECL_TYPE);
 
 	if (!type_decl_filename) {

--- a/src/maps.c
+++ b/src/maps.c
@@ -79,11 +79,11 @@ static struct hash_elem *look_up_hash_elem(const char *name, enum decl_flavor fl
 #if defined(__clang__) && defined(__clang_major__) && (__clang_major__ >= 4)
 __attribute__((no_sanitize("unsigned-integer-overflow")))
 #endif
-void insert_into_decl_map(const char *type, const char *module_name,
+void insert_into_decl_map(const char *name, const char *module_name,
                           enum decl_flavor flavor)
 {
 
-	struct hash_elem *decl = look_up_hash_elem(type, flavor);
+	struct hash_elem *decl = look_up_hash_elem(name, flavor);
 
 	if (decl == NULL) {     // Item not in hash table already
 
@@ -133,10 +133,10 @@ void insert_into_decl_map(const char *type, const char *module_name,
 	}       //TODO: else report error?
 }
 
-char *look_up_in_decl_map(const char *type, enum decl_flavor flavor)
+char *look_up_in_decl_map(const char *name, enum decl_flavor flavor)
 {
 
-	struct hash_elem *decl = look_up_hash_elem(type, flavor);
+	struct hash_elem *decl = look_up_hash_elem(name, flavor);
 
 	if (decl == NULL) {
 		return NULL;
@@ -219,7 +219,7 @@ char *look_up_in_mod_layers_map(const char *mod_name)
 #if defined(__clang__) && defined(__clang_major__) && (__clang_major__ >= 4)
 __attribute__((no_sanitize("unsigned-integer-overflow")))
 #endif
-void insert_into_ifs_map(const char *if_name, const char *module)
+void insert_into_ifs_map(const char *if_name, const char *mod_name)
 {
 
 	struct hash_elem *if_call;

--- a/src/maps.c
+++ b/src/maps.c
@@ -88,7 +88,7 @@ void insert_into_decl_map(const char *name, const char *module_name,
 	if (decl == NULL) {     // Item not in hash table already
 
 		decl = malloc(sizeof(struct hash_elem));
-		decl->key = strdup(type);
+		decl->key = strdup(name);
 		decl->val = strdup(module_name);
 
 		switch (flavor) {
@@ -133,7 +133,7 @@ void insert_into_decl_map(const char *name, const char *module_name,
 	}       //TODO: else report error?
 }
 
-char *look_up_in_decl_map(const char *name, enum decl_flavor flavor)
+const char *look_up_in_decl_map(const char *name, enum decl_flavor flavor)
 {
 
 	struct hash_elem *decl = look_up_hash_elem(name, flavor);
@@ -167,7 +167,7 @@ void insert_into_mods_map(const char *mod_name, const char *status)
 #if defined(__clang__) && defined(__clang_major__) && (__clang_major__ >= 4)
 __attribute__((no_sanitize("unsigned-integer-overflow")))
 #endif
-char *look_up_in_mods_map(const char *mod_name)
+const char *look_up_in_mods_map(const char *mod_name)
 {
 
 	struct hash_elem *mod;
@@ -203,7 +203,7 @@ void insert_into_mod_layers_map(const char *mod_name, const char *layer)
 #if defined(__clang__) && defined(__clang_major__) && (__clang_major__ >= 4)
 __attribute__((no_sanitize("unsigned-integer-overflow")))
 #endif
-char *look_up_in_mod_layers_map(const char *mod_name)
+const char *look_up_in_mod_layers_map(const char *mod_name)
 {
 	struct hash_elem *mod;
 
@@ -229,7 +229,7 @@ void insert_into_ifs_map(const char *if_name, const char *mod_name)
 	if (!if_call) {
 		if_call = malloc(sizeof(struct hash_elem));
 		if_call->key = strdup(if_name);
-		if_call->val = strdup(module);
+		if_call->val = strdup(mod_name);
 		HASH_ADD_KEYPTR(hh_ifs, ifs_map, if_call->key,
 		                strlen(if_call->key), if_call);
 	}
@@ -238,7 +238,7 @@ void insert_into_ifs_map(const char *if_name, const char *mod_name)
 #if defined(__clang__) && defined(__clang_major__) && (__clang_major__ >= 4)
 __attribute__((no_sanitize("unsigned-integer-overflow")))
 #endif
-char *look_up_in_ifs_map(const char *if_name)
+const char *look_up_in_ifs_map(const char *if_name)
 {
 
 	struct hash_elem *if_call;
@@ -473,7 +473,7 @@ void insert_call_into_template_map(const char *name, struct if_call_data *call)
 #if defined(__clang__) && defined(__clang_major__) && (__clang_major__ >= 4)
 __attribute__((no_sanitize("unsigned-integer-overflow")))
 #endif
-struct template_hash_elem *look_up_in_template_map(const char *name)
+const struct template_hash_elem *look_up_in_template_map(const char *name)
 {
 
 	struct template_hash_elem *template;
@@ -483,9 +483,9 @@ struct template_hash_elem *look_up_in_template_map(const char *name)
 	return template;
 }
 
-struct decl_list *look_up_decl_in_template_map(const char *name)
+const struct decl_list *look_up_decl_in_template_map(const char *name)
 {
-	struct template_hash_elem *template = look_up_in_template_map(name);
+	const struct template_hash_elem *template = look_up_in_template_map(name);
 
 	if (template) {
 		return template->declarations;
@@ -494,9 +494,9 @@ struct decl_list *look_up_decl_in_template_map(const char *name)
 	}
 }
 
-struct if_call_list *look_up_call_in_template_map(const char *name)
+const struct if_call_list *look_up_call_in_template_map(const char *name)
 {
-	struct template_hash_elem *template = look_up_in_template_map(name);
+	const struct template_hash_elem *template = look_up_in_template_map(name);
 
 	if (template) {
 		return template->calls;

--- a/src/maps.h
+++ b/src/maps.h
@@ -45,19 +45,19 @@ struct template_hash_elem {
 void insert_into_decl_map(const char *name, const char *module_name,
                           enum decl_flavor flavor);
 
-char *look_up_in_decl_map(const char *name, enum decl_flavor flavor);
+const char *look_up_in_decl_map(const char *name, enum decl_flavor flavor);
 
 void insert_into_mods_map(const char *mod_name, const char *status);
 
-char *look_up_in_mods_map(const char *mod_name);
+const char *look_up_in_mods_map(const char *mod_name);
 
 void insert_into_mod_layers_map(const char *mod_name, const char *layer);
 
-char *look_up_in_mod_layers_map(const char *mod_name);
+const char *look_up_in_mod_layers_map(const char *mod_name);
 
 void insert_into_ifs_map(const char *if_name, const char *mod_name);
 
-char *look_up_in_ifs_map(const char *if_name);
+const char *look_up_in_ifs_map(const char *if_name);
 
 void mark_transform_if(const char *if_name);
 
@@ -81,11 +81,11 @@ void insert_decl_into_template_map(const char *name, enum decl_flavor flavor,
 
 void insert_call_into_template_map(const char *name, struct if_call_data *call);
 
-struct template_hash_elem *look_up_in_template_map(const char *name);
+const struct template_hash_elem *look_up_in_template_map(const char *name);
 
-struct decl_list *look_up_decl_in_template_map(const char *name);
+const struct decl_list *look_up_decl_in_template_map(const char *name);
 
-struct if_call_list *look_up_call_in_template_map(const char *name);
+const struct if_call_list *look_up_call_in_template_map(const char *name);
 
 unsigned int decl_map_count(enum decl_flavor flavor);
 

--- a/src/maps.h
+++ b/src/maps.h
@@ -42,10 +42,10 @@ struct template_hash_elem {
 	UT_hash_handle hh;
 };
 
-void insert_into_decl_map(const char *type, const char *module_name,
+void insert_into_decl_map(const char *name, const char *module_name,
                           enum decl_flavor flavor);
 
-char *look_up_in_decl_map(const char *type, enum decl_flavor flavor);
+char *look_up_in_decl_map(const char *name, enum decl_flavor flavor);
 
 void insert_into_mods_map(const char *mod_name, const char *status);
 
@@ -55,7 +55,7 @@ void insert_into_mod_layers_map(const char *mod_name, const char *layer);
 
 char *look_up_in_mod_layers_map(const char *mod_name);
 
-void insert_into_ifs_map(const char *if_name, const char *module);
+void insert_into_ifs_map(const char *if_name, const char *mod_name);
 
 char *look_up_in_ifs_map(const char *if_name);
 

--- a/src/ordering.c
+++ b/src/ordering.c
@@ -308,7 +308,7 @@ static int is_own_module_rule(const struct policy_node *node, const char *curren
 	struct string_list *types = get_types_in_node(node);
 	struct string_list *cur = types;
 	while (cur) {
-		char *module_of_type_or_attr = look_up_in_decl_map(cur->string, DECL_TYPE);
+		const char *module_of_type_or_attr = look_up_in_decl_map(cur->string, DECL_TYPE);
 		if (!module_of_type_or_attr) {
 			module_of_type_or_attr = look_up_in_decl_map(cur->string, DECL_ATTRIBUTE);
 		}
@@ -333,7 +333,7 @@ static int is_kernel_mod_if_call(const struct policy_node *node)
 	if (node->flavor != NODE_IF_CALL) {
 		return 0;
 	}
-	char *mod_name = look_up_in_ifs_map(node->data.ic_data->name);
+	const char *mod_name = look_up_in_ifs_map(node->data.ic_data->name);
 	if (!mod_name) {
 		return 0;
 	}
@@ -365,12 +365,12 @@ static int check_call_layer(const struct policy_node *node, const char *layer_to
 	if (node->flavor != NODE_IF_CALL) {
 		return 0;
 	}
-	char *mod_name = look_up_in_ifs_map(node->data.ic_data->name);
+	const char *mod_name = look_up_in_ifs_map(node->data.ic_data->name);
 	if (!mod_name) {
 		// not an actual interface
 		return 0;
 	}
-	char *layer_name = look_up_in_mod_layers_map(mod_name);
+	const char *layer_name = look_up_in_mod_layers_map(mod_name);
 	if (!layer_name) {
 		return 0;
 	}

--- a/src/te_checks.c
+++ b/src/te_checks.c
@@ -312,7 +312,7 @@ struct check_result *check_no_explicit_declaration(const struct check_data *data
 	struct string_list *type = types;
 
 	while (type) {
-		char *mod_name = look_up_in_decl_map(type->string, DECL_TYPE);
+		const char *mod_name = look_up_in_decl_map(type->string, DECL_TYPE);
 		if (!mod_name) {
 			//Not a type
 			type = type->next;
@@ -345,7 +345,7 @@ struct check_result *check_module_if_call_in_optional(const struct check_data
 
 	struct if_call_data *if_data = node->data.ic_data;
 
-	char *if_mod_name = look_up_in_ifs_map(if_data->name);
+	const char *if_mod_name = look_up_in_ifs_map(if_data->name);
 
 	if (!if_mod_name) {
 		// Not defined as an interface.  Probably a macro
@@ -357,7 +357,7 @@ struct check_result *check_module_if_call_in_optional(const struct check_data
 		return NULL;
 	}
 
-	char *mod_type = look_up_in_mods_map(if_mod_name);
+	const char *mod_type = look_up_in_mods_map(if_mod_name);
 
 	if (!mod_type || 0 != strcmp(mod_type, "module")) {
 		// If mod_type is NULL, we have no info on this module.  We *should* have info

--- a/src/template.c
+++ b/src/template.c
@@ -112,7 +112,7 @@ enum selint_error add_template_declarations(const char *template_name,
 	cur->string = strdup(template_name);
 	cur->next = parent_temp_names;
 
-	struct if_call_list *calls =
+	const struct if_call_list *calls =
 		look_up_call_in_template_map(template_name);
 
 	while (calls) {
@@ -130,7 +130,7 @@ enum selint_error add_template_declarations(const char *template_name,
 		calls = calls->next;
 	}
 
-	struct decl_list *decls = look_up_decl_in_template_map(template_name);
+	const struct decl_list *decls = look_up_decl_in_template_map(template_name);
 
 	while (decls) {
 		char *new_decl = replace_m4(decls->decl->name, args);

--- a/tests/check_maps.c
+++ b/tests/check_maps.c
@@ -24,7 +24,7 @@ START_TEST (test_insert_into_type_map) {
 	insert_into_decl_map("bar_t", "test_module", DECL_TYPE);
 	insert_into_decl_map("baz_t", "other_module", DECL_TYPE);
 
-	char *mod_name = look_up_in_decl_map("doesntexist", DECL_TYPE);
+	const char *mod_name = look_up_in_decl_map("doesntexist", DECL_TYPE);
 
 	ck_assert_ptr_null(mod_name);
 
@@ -66,7 +66,7 @@ START_TEST (test_role_and_user_maps) {
 	insert_into_decl_map("bar_r", "test_module2", DECL_ROLE);
 	insert_into_decl_map("bar_u", "test_module3", DECL_USER);
 
-	char *mod_name = look_up_in_decl_map("foo_r", DECL_TYPE);
+	const char *mod_name = look_up_in_decl_map("foo_r", DECL_TYPE);
 
 	ck_assert_ptr_null(mod_name);
 
@@ -102,7 +102,7 @@ START_TEST (test_class_and_perm_maps) {
 	insert_into_decl_map("file", "class", DECL_CLASS);
 	insert_into_decl_map("read", "perm", DECL_PERM);
 
-	char *res = look_up_in_decl_map("dir", DECL_CLASS);
+	const char *res = look_up_in_decl_map("dir", DECL_CLASS);
 
 	ck_assert_ptr_null(res);
 
@@ -126,7 +126,7 @@ START_TEST (test_mods_map) {
 	insert_into_mods_map("systemd", "base");
 	insert_into_mods_map("games", "off");
 
-	char *res = look_up_in_mods_map("systemd");
+	const char *res = look_up_in_mods_map("systemd");
 	ck_assert_str_eq("base", res);
 
 	res = look_up_in_mods_map("games");
@@ -148,7 +148,7 @@ START_TEST (test_insert_decl_into_template_map) {
 
 	insert_decl_into_template_map("other_template", DECL_TYPE, "$1_conf_t");
 
-	struct decl_list *dl = look_up_decl_in_template_map("doesntexist");
+	const struct decl_list *dl = look_up_decl_in_template_map("doesntexist");
 	ck_assert_ptr_null(dl);
 
 	dl = look_up_decl_in_template_map("user_domain");
@@ -202,7 +202,7 @@ START_TEST (test_insert_call_into_template_map) {
 
 	insert_decl_into_template_map("user_domain", DECL_TYPE, "$1_conf_t");
 
-	struct if_call_list *out = look_up_call_in_template_map("user_domain");
+	const struct if_call_list *out = look_up_call_in_template_map("user_domain");
 
 	ck_assert_ptr_eq(call, out->call);
 

--- a/tests/check_parse_functions.c
+++ b/tests/check_parse_functions.c
@@ -103,7 +103,7 @@ START_TEST (test_insert_declaration) {
 
 	// TODO attributes
 
-	char *mn = look_up_in_decl_map("foo_t", DECL_TYPE);
+	const char *mn = look_up_in_decl_map("foo_t", DECL_TYPE);
 
 	ck_assert_ptr_nonnull(mn);
 


### PR DESCRIPTION
We do not want to alter the internal policy state via a lookup function.

Improve maps function argument names (`type` -> `name`, `module` -> `mod_name`)