### PR TITLE
Check for conversion compiler warnings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,8 @@ jobs:
     - name: autogen
       run: ./autogen.sh
     - name: configure
-      run: ./configure CFLAGS="-Werror"
+      # old flex/bison versions might not generate conversion warning free code
+      run: ./configure CFLAGS="-Werror -Wno-error=conversion -Wno-error=sign-conversion"
     - name: make
       run: make
     - name: make check
@@ -78,7 +79,7 @@ jobs:
         make VERSION=pipeline-test dist
         tar xvzf selint-pipeline-test.tar.gz
         cd selint-pipeline-test
-        ./configure CFLAGS="-Werror"
+        ./configure CFLAGS="-Werror -Wno-error=conversion -Wno-error=sign-conversion"
         make
         cd tests/functional
         bats end-to-end.bats

--- a/configure.ac
+++ b/configure.ac
@@ -76,7 +76,7 @@ AX_VALGRIND_CHECK
 
 AC_CHECK_HEADER([uthash.h], [], [AC_MSG_ERROR([Unable to find uthash header])])
 
-AM_CFLAGS="-Wall -Wextra -Wmissing-format-attribute -Wmissing-noreturn -Wpointer-arith -Wshadow -Wstrict-prototypes -Wundef -Wunused -Wwrite-strings"
+AM_CFLAGS="-Wall -Wextra -Wconversion -Wmissing-format-attribute -Wmissing-noreturn -Wpointer-arith -Wshadow -Wstrict-prototypes -Wundef -Wunused -Wwrite-strings"
 AC_SUBST([AM_CFLAGS])
 
 AC_CONFIG_FILES([Makefile src/Makefile tests/Makefile man/Makefile])

--- a/src/check_hooks.c
+++ b/src/check_hooks.c
@@ -99,7 +99,7 @@ void display_check_result(const struct check_result *res, const struct check_dat
 	if (FILENAME_PADDING < len) {
 		padding = 0;
 	} else {
-		padding = FILENAME_PADDING - len;
+		padding = (unsigned)(FILENAME_PADDING - len);
 	}
 
 	printf("%s:%*u: %s(%c)%s: %s (%c-%03u)\n",
@@ -188,8 +188,8 @@ static int comp_check_nodes(const void *n1, const void *n2)
 	const struct check_node *node1 = *(struct check_node **)n1;
 	const struct check_node *node2 = *(struct check_node **)n2;
 
-	unsigned int node1_id = atoi(node1->check_id + 2);
-	unsigned int node2_id = atoi(node2->check_id + 2);
+	int node1_id = atoi(node1->check_id + 2);
+	int node2_id = atoi(node2->check_id + 2);
 
 	switch (node1->check_id[0]) {
 	case 'C':

--- a/src/main.c
+++ b/src/main.c
@@ -360,7 +360,7 @@ int main(int argc, char **argv)
 	struct policy_file_list *context_if_files =
 		calloc(1, sizeof(struct policy_file_list));
 
-	char **paths = malloc(sizeof(char *) * argc - optind + 2);
+	char **paths = malloc(sizeof(char *) * (unsigned)argc - (unsigned)optind + 2);
 
 	int i = 0;
 	while (optind < argc) {

--- a/src/ordering.c
+++ b/src/ordering.c
@@ -782,15 +782,20 @@ char *get_ordering_reason(struct ordering_metadata *order_data, unsigned int ind
 
 	char *ret = malloc(sizeof(char) * str_len);
 
-	size_t written = snprintf(ret, str_len,
-	                          "Line out of order.  It is of type %s %s line %u %s.",
-	                          lss_to_string(get_local_subsection(order_data->mod_name, this_node)),
-	                          before_after,
-	                          other_node->lineno,
-	                          reason_str);
+	ssize_t written = snprintf(ret, str_len,
+	                           "Line out of order.  It is of type %s %s line %u %s.",
+	                           lss_to_string(get_local_subsection(order_data->mod_name, this_node)),
+	                           before_after,
+	                           other_node->lineno,
+	                           reason_str);
+
+	if (written < 0) {
+		free(followup_str);
+		return NULL;
+	}
 
 	if (followup_str) {
-		strncat(ret, followup_str, str_len - written);
+		strncat(ret, followup_str, str_len - (size_t)written);
 	}
 
 	free(followup_str);

--- a/src/template.c
+++ b/src/template.c
@@ -47,7 +47,7 @@ char *replace_m4(const char *orig, const struct string_list *args)
 			strcpy(ret_pos, orig_pos);
 			break;
 		}
-		strncpy(ret_pos, orig_pos, dollar_pos - orig_pos);
+		strncpy(ret_pos, orig_pos, (size_t)(dollar_pos - orig_pos));
 		ret_pos += dollar_pos - orig_pos;
 		orig_pos = dollar_pos;
 

--- a/tests/check_ordering.c
+++ b/tests/check_ordering.c
@@ -53,7 +53,7 @@ START_TEST (test_prepare_ordering_metadata) {
 	ck_assert_ptr_nonnull(o);
 	ck_assert_ptr_nonnull(o->sections);
 	ck_assert_ptr_nonnull(o->sections->section_name);
-	ck_assert_int_eq(o->order_node_len, 3);
+	ck_assert_uint_eq(o->order_node_len, 3);
 	ck_assert_ptr_null(o->nodes[0].node);
 	ck_assert_ptr_null(o->nodes[1].node);
 	ck_assert_ptr_null(o->nodes[2].node);


### PR DESCRIPTION
Exclude them from Werror on CI runs though, cause the ubuntu bison/flex versions do not generate warning free code