### PR TITLE
Pretty parser

### DIFF
--- a/src/lex.l
+++ b/src/lex.l
@@ -108,4 +108,10 @@ userdebug_or_eng { return USERDEBUG_OR_ENG; }
 (\#.*)?\n { yylineno++; }
 dnl(.*)?\n { yylineno++; }
 [ \t] ; /* normally skip whitespace */
-. { char *str = malloc(strlen(yytext) + 1); sprintf(str, "Invalid character: %s", yytext); yyerror(str); free(str); }
+. {
+    const size_t len = strlen("Invalid character: ") + 1 /*character*/ + 2 /*quotes*/ + 1 /*null*/;
+    char *str = malloc(len);
+    snprintf(str, len, "Invalid character: '%c'", *yytext);
+    yyerror(str);
+    free(str);
+  }

--- a/src/lex.l
+++ b/src/lex.l
@@ -24,6 +24,7 @@ extern void yyerror(const char *);
 %option nounput
 %option noinput
 %option noyywrap
+%option nodefault
 %%
 policy_module { return POLICY_MODULE; }
 module { return MODULE; }

--- a/src/lex.l
+++ b/src/lex.l
@@ -18,13 +18,13 @@
 #include <string.h>
 #include "tree.h"
 #include "parse.h"
-int yylineno;
 extern void yyerror(const char *);
 %}
 %option nounput
 %option noinput
 %option noyywrap
 %option nodefault
+%option yylineno
 %%
 policy_module { return POLICY_MODULE; }
 module { return MODULE; }
@@ -103,10 +103,10 @@ userdebug_or_eng { return USERDEBUG_OR_ENG; }
 \!\= { return NOT_EQUAL; }
 \! { return NOT; }
 \=\= { return EQUAL; }
-^\#.*\n { yylineno++; return COMMENT; }
-\#selint\-disable\:[CSWEF]\-[0-9]+(\,[CSWEF]\-[0-9]+)*\n { yylineno++; yylval.string = strdup(yytext); return SELINT_COMMAND; }
-(\#.*)?\n { yylineno++; }
-dnl(.*)?\n { yylineno++; }
+^\#.*\n { return COMMENT; }
+\#selint\-disable\:[CSWEF]\-[0-9]+(\,[CSWEF]\-[0-9]+)*\n { yylval.string = strdup(yytext); return SELINT_COMMAND; }
+(\#.*)?\n ;
+dnl(.*)?\n ;
 [ \t] ; /* normally skip whitespace */
 . {
     const size_t len = strlen("Invalid character: ") + 1 /*character*/ + 2 /*quotes*/ + 1 /*null*/;

--- a/src/lex.l
+++ b/src/lex.l
@@ -23,6 +23,7 @@ extern void yyerror(const char *);
 %}
 %option nounput
 %option noinput
+%option noyywrap
 %%
 policy_module { return POLICY_MODULE; }
 module { return MODULE; }
@@ -108,16 +109,3 @@ dnl(.*)?\n { yylineno++; }
 [ \t] ; /* normally skip whitespace */
 \% { yyerror("Invalid character: %%"); /* will be run through printf again */ }
 . { char *str = malloc(strlen(yytext) + 1); sprintf(str, "Invalid character: %s", yytext); yyerror(str); free(str); }
-
-%%
-int yywrap(void) {
-	return 1;
-}
-/*
-int main() {
-	for(int i=0; i < 20; i++) {
-		yylex();
-	}
-	return 0;
-}
-*/

--- a/src/lex.l
+++ b/src/lex.l
@@ -107,5 +107,4 @@ userdebug_or_eng { return USERDEBUG_OR_ENG; }
 (\#.*)?\n { yylineno++; }
 dnl(.*)?\n { yylineno++; }
 [ \t] ; /* normally skip whitespace */
-\% { yyerror("Invalid character: %%"); /* will be run through printf again */ }
 . { char *str = malloc(strlen(yytext) + 1); sprintf(str, "Invalid character: %s", yytext); yyerror(str); free(str); }

--- a/src/parse.y
+++ b/src/parse.y
@@ -13,6 +13,9 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+
+%define parse.error verbose
+
 %{
 	#include <stdio.h>
 	#include <string.h>


### PR DESCRIPTION
* Use Lex option `noyywrap` instead of implementing `yywrap()`
* Drop explicit lexer rule for unknown `%` character
* Add Lex option `nodefault`
* Fix Lex catch-all rule
* Use Lex option `yylineno` instead of manual handling
* Enable more verbose syntax error messages





