### PR TITLE
Extend C-005 to check for repeated perms

### DIFF
--- a/src/te_checks.c
+++ b/src/te_checks.c
@@ -100,12 +100,21 @@ struct check_result *check_unordered_perms(__attribute__((unused)) const struct 
 	}
 
 	while (cur) {
-		if (prev && strcmp(prev->string, "~") != 0 && strcmp(prev->string, cur->string) > 0) {
-			return make_check_result('C', C_ID_UNORDERED_PERM,
-			                         "Permissions in %s not ordered (%s before %s)",
-			                         flavor,
-			                         prev->string,
-			                         cur->string);
+		if (prev && strcmp(prev->string, "~") != 0) {
+			const int compare = strcmp(prev->string, cur->string);
+
+			if (compare > 0) {
+				return make_check_result('C', C_ID_UNORDERED_PERM,
+			                                 "Permissions in %s not ordered (%s before %s)",
+			                                 flavor,
+			                                 prev->string,
+			                                 cur->string);
+			} else if (compare == 0) {
+				return make_check_result('C', C_ID_UNORDERED_PERM,
+			                                 "Permissions in %s repeated (%s)",
+			                                 flavor,
+			                                 cur->string);
+			}
 		}
 
 		prev = cur;

--- a/tests/functional/end-to-end.bats
+++ b/tests/functional/end-to-end.bats
@@ -88,7 +88,7 @@ test_one_check() {
 }
 
 @test "C-005" {
-	test_one_check "C-005" "c05.te"
+	test_one_check_expect "C-005" "c05.te" 2
 	test_one_check "C-005" "c05.if"
 }
 

--- a/tests/functional/policies/check_triggers/c05.te
+++ b/tests/functional/policies/check_triggers/c05.te
@@ -1,3 +1,5 @@
 policy_module(c05, 1.0)
 
 allow source target:cls { foo bar };
+
+allow source target:cls { foo foo };


### PR DESCRIPTION
We only find repeated perms not duplicated, e.g.
    allow source target:cls { perm1 perm2 perm2 };
but not
    allow source target:cls { perm2 perm1 perm2 };

This would require a new check with additional computation.
Doing this here comes for free.

Refpolicy findings:
udev.te:             48: (C): Permissions in av rule repeated (sys_nice) (C-005)
cups.te:            112: (C): Permissions in av rule repeated (dac_override) (C-005)