### PR TITLE
Add configure option to disable Check unit tests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -13,11 +13,15 @@
 # limitations under the License.
 
 AUTOMAKE_OPTIONS = foreign
+
+if WITH_CHECK
 SUBDIRS = src . tests . man
+check-valgrind:
+	CK_FORK=no $(MAKE) -C tests check-valgrind-memcheck-am
+else
+SUBDIRS = src . man
+endif
 
 selintconfdir = $(sysconfdir)
 selintconf_DATA = selint.conf
 EXTRA_DIST = selint.conf CHANGELOG LICENSE NOTICE check_examples.txt
-
-check-valgrind:
-	CK_FORK=no $(MAKE) -C tests check-valgrind-memcheck-am

--- a/configure.ac
+++ b/configure.ac
@@ -28,7 +28,14 @@ AC_PROG_CC_STDC
 AC_PROG_LEX
 AC_PROG_YACC
 
-PKG_CHECK_MODULES([CHECK], [check >= 0.11.0], [], [AC_MSG_ERROR([Check not found])])
+# Check for testsuite Check library
+AC_ARG_ENABLE([check],
+        [AS_HELP_STRING([--disable-check],
+                [Disable testsuite depending on Check (default: testsuite is enabled)])],
+                [enable_check=${enableval}],
+                [enable_check=yes])
+AM_CONDITIONAL([WITH_CHECK], [test "x$enable_check" = "xyes"])
+AS_IF([test "x$enable_check" = "xyes"], [PKG_CHECK_MODULES([CHECK], [check >= 0.11.0], [], [AC_MSG_ERROR([Check not found])])])
 
 # Checks for libraries.
 AC_SEARCH_LIBS([cfg_init], [confuse], [], [


### PR DESCRIPTION
Add option `--disable-check` to be able to build SELint on systems without or with a too old version of Check.