### PR TITLE
Misc

### DIFF
--- a/src/check_hooks.c
+++ b/src/check_hooks.c
@@ -309,21 +309,22 @@ struct check_result *make_check_result(char severity, unsigned int check_id,
 
 void free_checks(struct checks *to_free)
 {
+	if (to_free == NULL) {
+		return;
+	}
+
 	for (int i=0; i < NODE_ERROR + 1; i++) {
-		if (to_free->check_nodes[i]) {
-			free_check_node(to_free->check_nodes[i]);
-		}
+		free_check_node(to_free->check_nodes[i]);
 	}
 	free(to_free);
 }
 
 void free_check_node(struct check_node *to_free)
 {
-
-	if (to_free->next) {
-		free_check_node(to_free->next);
+	while (to_free) {
+		struct check_node *tmp = to_free;
+		to_free = to_free->next;
+		free(tmp->check_id);
+		free(tmp);
 	}
-	free(to_free->check_id);
-	free(to_free);
-
 }

--- a/src/fc_checks.c
+++ b/src/fc_checks.c
@@ -26,7 +26,7 @@
 	if (node->flavor != NODE_FC_ENTRY) { \
 		return alloc_internal_error("File context type check called on non file context entry"); \
 	} \
-	struct fc_entry *entry = node->data.fc_data; \
+	const struct fc_entry *entry = node->data.fc_data; \
 	if (!entry) { \
 		return alloc_internal_error("Policy node data field is NULL"); \
 	} \
@@ -106,7 +106,7 @@ struct check_result *check_file_context_regex(__attribute__((unused)) const stru
 
 	SETUP_FOR_FC_CHECK(node)
 
-	char *path = entry->path;
+	const char *path = entry->path;
 	char cur = *path;
 	char prev = '\0';
 	int error = 0;

--- a/src/ordering.c
+++ b/src/ordering.c
@@ -673,6 +673,9 @@ char *get_ordering_reason(struct ordering_metadata *order_data, unsigned int ind
 	case ORDER_SECTION:
 		node_section = get_section(this_node);
 		other_section = get_section(other_node);
+		if (!node_section || !other_section) {
+			return NULL; // Error
+		}
 		if (0 == strcmp("_declarations", node_section)) {
 			// This is the first section
 			reason_str = "that is not a declaration";

--- a/src/parse.y
+++ b/src/parse.y
@@ -489,32 +489,27 @@ require_line:
 
 require_bare:
 	TYPE comma_string_list SEMICOLON {
-		const struct string_list *iter = $2;
-		for (iter = $2; iter; iter = iter->next) insert_declaration(&cur, DECL_TYPE, iter->string, NULL, yylineno);
+		for (const struct string_list *iter = $2; iter; iter = iter->next) insert_declaration(&cur, DECL_TYPE, iter->string, NULL, yylineno);
 		free_string_list($2);
 		}
 	|
 	ATTRIBUTE comma_string_list SEMICOLON {
-		const struct string_list *iter = $2;
-		for (iter = $2; iter; iter = iter->next) insert_declaration(&cur, DECL_ATTRIBUTE, iter->string, NULL, yylineno);
+		for (const struct string_list *iter = $2; iter; iter = iter->next) insert_declaration(&cur, DECL_ATTRIBUTE, iter->string, NULL, yylineno);
 		free_string_list($2);
 		}
 	|
 	ROLE comma_string_list SEMICOLON {
-		const struct string_list *iter = $2;
-		for (iter = $2; iter; iter = iter->next) insert_declaration(&cur, DECL_ROLE, iter->string, NULL, yylineno);
+		for (const struct string_list *iter = $2; iter; iter = iter->next) insert_declaration(&cur, DECL_ROLE, iter->string, NULL, yylineno);
 		free_string_list($2);
 		}
 	|
 	ATTRIBUTE_ROLE comma_string_list SEMICOLON {
-		const struct string_list *iter = $2;
-		for (iter = $2; iter; iter = iter->next) insert_declaration(&cur, DECL_ATTRIBUTE_ROLE, iter->string, NULL, yylineno);
+		for (const struct string_list *iter = $2; iter; iter = iter->next) insert_declaration(&cur, DECL_ATTRIBUTE_ROLE, iter->string, NULL, yylineno);
 		free_string_list($2);
 		}
 	|
 	BOOL comma_string_list SEMICOLON {
-		const struct string_list *iter = $2;
-		for (iter = $2; iter; iter = iter->next) insert_declaration(&cur, DECL_BOOL, iter->string, NULL, yylineno);
+		for (const struct string_list *iter = $2; iter; iter = iter->next) insert_declaration(&cur, DECL_BOOL, iter->string, NULL, yylineno);
 		free_string_list($2);
 		}
 	|

--- a/src/parse_functions.c
+++ b/src/parse_functions.c
@@ -374,8 +374,6 @@ enum selint_error insert_role_transition(struct policy_node **cur,
 
 static int is_filetrans_if_name(const char *if_name)
 {
-	const char *suffix;
-
 	if (0 == strcmp(if_name, "filetrans_pattern")) {
 		return 1;
 	}
@@ -384,7 +382,7 @@ static int is_filetrans_if_name(const char *if_name)
 		return 1;
 	}
 
-	suffix = strrchr(if_name, '_');
+	const char *suffix = strrchr(if_name, '_');
 	if (suffix &&
 	    (0 == strcmp(suffix, "_filetrans"))) {
 		return 1;

--- a/src/startup.c
+++ b/src/startup.c
@@ -176,8 +176,8 @@ IGNORE_CONST_DISCARD_END;
 
 	FTSENT *file = fts_read(ftsp);
 	while (file) {
-		char *suffix = file->fts_path + file->fts_pathlen - 3;
-		if (!strcmp(suffix, ".if")) {
+		const char *suffix = (file->fts_pathlen > 3) ? (file->fts_path + file->fts_pathlen - 3) : NULL;
+		if (suffix && !strcmp(suffix, ".if")) {
 			file_list_push_back(context_files,
 			                    make_policy_file(file->fts_path,
 			                                     NULL));


### PR DESCRIPTION
* Handle devel headers with very short name
* Move variable declarations into for loops
* Prolong variable declaration to assignment
* Avoid theoretical null dereference
* Mark filecontext check variables const
* Use a loop instead of recursion
* Rework freeing check nodes