### PR TITLE
Add check for unordered declarations in require blocks

### DIFF
--- a/README
+++ b/README
@@ -150,6 +150,7 @@ CHECK IDS
 	C-001: Violation of refpolicy te file ordering conventions
 	C-004: Interface does not have documentation comment
 	C-005: Permissions in av rule or class declaration not ordered
+	C-006: Declarations in require block not ordered
 
 	S-001: Require block used instead of interface call
 	S-002: File context file labels with type not declared in module

--- a/check_examples.txt
+++ b/check_examples.txt
@@ -21,6 +21,13 @@ C-005:
 
 	allow foo_t bar_t:file { write read };
 
+C-006:
+
+	gen_require(`
+		type foo_t, bar_t;
+		class foobar;
+	')
+
 Style:
 
 S-001:

--- a/selint.conf
+++ b/selint.conf
@@ -17,7 +17,7 @@ severity = "convention"
 
 # Uncomment and modify to disable selected checks.  This can be overridden on
 # the command line
-disable = { C-001, W-010, W-011, E-003, E-004 }
+disable = { C-001, C-006, W-010, W-011, E-003, E-004 }
 
 # enable description
 #enable_normal = { S-002, E-002 }
@@ -47,6 +47,17 @@ assume_roles = { object_r }
 # - refpolicy-lax: (default) Similar to refpolicy, but ignore interface
 #   and block ordering requirements.
 ordering_rules = "refpolicy-lax"
+
+# What ordering in require blocks you would like to apply when running check C-006
+# The following six flavors must each be used exactly once:
+#   attribute, attribute_role, bool, class, role, type
+# If unset, this defaults to the following order:
+#ordering_requires = { bool, role, attribute_role, attribute, type, class }
+ordering_requires = { bool, attribute, attribute_role, type, class, role }
+
+# Whether to check the order (alphabetically) of requires of the same flavor when running check C-006
+# If unset, this defaults to true.
+ordering_requires_same_flavor = false
 
 # Whether to ignore known false-positives on generated policy files.
 # In recursive mode SELint checks all files with known endings, regardless

--- a/src/check_hooks.h
+++ b/src/check_hooks.h
@@ -25,6 +25,7 @@ enum convention_ids {
 	C_ID_TE_ORDER       = 1,
 	C_ID_IF_COMMENT     = 4,
 	C_ID_UNORDERED_PERM = 5,
+	C_ID_UNORDERED_REQ  = 6,
 	C_END
 };
 

--- a/src/if_checks.h
+++ b/src/if_checks.h
@@ -33,6 +33,19 @@ struct check_result *check_interface_definitions_have_comment(const struct
                                                               *node);
 
 /*********************************************
+* Check that declaration in require blocks are ordered
+* Called on NODE_REQUIRE and NODE_GEN_REQ nodes.
+* data - metadata about the file
+* node - the node to check
+* returns NULL if passed or check_result for issue C-006
+*********************************************/
+struct check_result *check_unordered_declaration_in_require(const struct
+                                                            check_data *data,
+                                                            const struct
+                                                            policy_node
+                                                            *node);
+
+/*********************************************
 * Check that interfaces do not call templates
 * Called on NODE_IF_CALL nodes
 * data - metadata about the file

--- a/src/runner.c
+++ b/src/runner.c
@@ -128,6 +128,12 @@ struct checks *register_checks(char level,
 			add_check(NODE_DECL, ck, "C-005",
 			          check_unordered_perms);
 		}
+		if (CHECK_ENABLED("C-006")) {
+			add_check(NODE_REQUIRE, ck, "C-006",
+			          check_unordered_declaration_in_require);
+			add_check(NODE_GEN_REQ, ck, "C-006",
+			          check_unordered_declaration_in_require);
+		}
 		// FALLTHRU
 	case 'S':
 		if (CHECK_ENABLED("S-001")) {

--- a/src/selint_config.h
+++ b/src/selint_config.h
@@ -31,6 +31,8 @@ enum order_conf {
 
 struct config_check_data {
 	enum order_conf order_conf;
+	enum decl_flavor order_requires[6];
+	bool ordering_requires_same_flavor;
 	bool skip_checking_generated_fcs;
 };
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -88,7 +88,8 @@ SAMPLE_CONFIG_FILES=sample_configs/bad_format_2.conf \
 			sample_configs/severity_style.conf \
 			sample_configs/severity_warning.conf \
 			sample_configs/bad_order.conf \
-			sample_configs/refpolicy_ordering.conf
+			sample_configs/refpolicy_ordering.conf \
+			sample_configs/order_requires.conf
 
 SAMPLE_POLICY_FILES=sample_policy_files/bad_modules.conf \
 			sample_policy_files/bad_obj_perm_sets.spt \
@@ -122,6 +123,8 @@ FUNCTIONAL_TEST_FILES=functional/end-to-end.bats \
 			functional/policies/check_triggers/c04.if \
 			functional/policies/check_triggers/c05.if \
 			functional/policies/check_triggers/c05.te \
+			functional/policies/check_triggers/c06.pass.if \
+			functional/policies/check_triggers/c06.warn.if \
 			functional/policies/check_triggers/e02.fc \
 			functional/policies/check_triggers/e03e04e05.fc \
 			functional/policies/check_triggers/e06.te \

--- a/tests/check_fc_checks.c
+++ b/tests/check_fc_checks.c
@@ -97,7 +97,7 @@ START_TEST (test_check_file_context_types_in_mod) {
 	data->filename = strdup("foo");
 	data->mod_name = strdup("foo");
 	data->flavor = FILE_FC_FILE;
-	struct config_check_data cfg = { ORDER_LAX, true };
+	const struct config_check_data cfg = { ORDER_LAX, {}, true, true };
 	data->config_check_data = &cfg;
 
 	struct policy_node *node = malloc(sizeof(struct policy_node));

--- a/tests/check_selint_config.c
+++ b/tests/check_selint_config.c
@@ -28,6 +28,7 @@
 #define SEVERITY_FATAL_FILENAME CONFIGS_DIR "severity_fatal.conf"
 #define CHECKS_FILENAME CONFIGS_DIR "check_config.conf"
 #define REFPOL_ORDERING_FILENAME CONFIGS_DIR "refpolicy_ordering.conf"
+#define ORDER_REQUIRES_FILENAME CONFIGS_DIR "order_requires.conf"
 #define BAD_FORMAT_1 CONFIGS_DIR "bad_format.conf"
 #define BAD_FORMAT_2 CONFIGS_DIR "bad_format_2.conf"
 #define BAD_OPTION CONFIGS_DIR "invalid_option.conf"
@@ -92,13 +93,40 @@ START_TEST (test_parse_config_checks) {
 }
 END_TEST
 
-START_TEST (test_parse_config_ordering) {
+START_TEST (test_parse_config_ordering_rules) {
 	char severity = '\0';
 	struct config_check_data ccd;
 
 	ck_assert_int_eq(SELINT_SUCCESS, parse_config(REFPOL_ORDERING_FILENAME, 0, &severity, NULL, NULL, NULL, &ccd));
 
 	ck_assert_int_eq(ORDER_REF, ccd.order_conf);
+}
+END_TEST
+
+START_TEST (test_parse_config_ordering_requires) {
+
+	char severity = '\0';
+	struct config_check_data ccd;
+
+	// default
+	ck_assert_int_eq(SELINT_SUCCESS, parse_config("", 0, &severity, NULL, NULL, NULL, &ccd));
+	ck_assert_int_eq(DECL_BOOL, ccd.order_requires[0]);
+	ck_assert_int_eq(DECL_CLASS, ccd.order_requires[1]);
+	ck_assert_int_eq(DECL_ROLE, ccd.order_requires[2]);
+	ck_assert_int_eq(DECL_ATTRIBUTE_ROLE, ccd.order_requires[3]);
+	ck_assert_int_eq(DECL_ATTRIBUTE, ccd.order_requires[4]);
+	ck_assert_int_eq(DECL_TYPE, ccd.order_requires[5]);
+	ck_assert_int_eq(true, ccd.ordering_requires_same_flavor);
+
+	// custom
+	ck_assert_int_eq(SELINT_SUCCESS, parse_config(ORDER_REQUIRES_FILENAME, 0, &severity, NULL, NULL, NULL, &ccd));
+	ck_assert_int_eq(DECL_BOOL, ccd.order_requires[0]);
+	ck_assert_int_eq(DECL_ATTRIBUTE, ccd.order_requires[1]);
+	ck_assert_int_eq(DECL_ATTRIBUTE_ROLE, ccd.order_requires[2]);
+	ck_assert_int_eq(DECL_TYPE, ccd.order_requires[3]);
+	ck_assert_int_eq(DECL_CLASS, ccd.order_requires[4]);
+	ck_assert_int_eq(DECL_ROLE, ccd.order_requires[5]);
+	ck_assert_int_eq(false, ccd.ordering_requires_same_flavor);
 }
 END_TEST
 
@@ -146,7 +174,8 @@ Suite *selint_config_suite(void) {
 
 	tcase_add_test(tc_core, test_parse_config_severity);
 	tcase_add_test(tc_core, test_parse_config_checks);
-	tcase_add_test(tc_core, test_parse_config_ordering);
+	tcase_add_test(tc_core, test_parse_config_ordering_rules);
+	tcase_add_test(tc_core, test_parse_config_ordering_requires);
 	tcase_add_test(tc_core, test_bad_configs);
 	suite_add_tcase(s, tc_core);
 

--- a/tests/functional/end-to-end.bats
+++ b/tests/functional/end-to-end.bats
@@ -92,6 +92,11 @@ test_one_check() {
 	test_one_check "C-005" "c05.if"
 }
 
+@test "C-006" {
+	test_one_check_expect "C-006" "c06.pass.if" 0
+	test_one_check_expect "C-006" "c06.warn.if" 5
+}
+
 @test "S-001" {
 	test_one_check "S-001" "s01.te"
 }

--- a/tests/functional/policies/check_triggers/c06.pass.if
+++ b/tests/functional/policies/check_triggers/c06.pass.if
@@ -1,0 +1,16 @@
+# comment
+interface(`c06_interface',`
+	gen_require(`
+		bool c06_bool;
+		class a { a_perm };
+		class b { b_perm };
+		role sysadm_r;
+		attribute_role c06_roles;
+		attribute c06_domain;
+		type c06_t, c06_exec_t;
+		type c06_tmp_t;
+		type c06_unit_t;
+	')
+
+	# empty
+')

--- a/tests/functional/policies/check_triggers/c06.warn.if
+++ b/tests/functional/policies/check_triggers/c06.warn.if
@@ -1,0 +1,24 @@
+# comment
+interface(`c06_fail_interface',`
+	gen_require(`
+		type foo;
+		class bar { bar_perm };
+	')
+
+	gen_require(`
+		type foo, bar;
+	')
+
+	gen_require(`
+		type foo;
+		type bar;
+	')
+
+	gen_require(`
+		type bar_conf_t, bar_t;
+	')
+
+	gen_require(`
+		type foo_t, foo_t;
+	')
+')

--- a/tests/sample_configs/order_requires.conf
+++ b/tests/sample_configs/order_requires.conf
@@ -1,0 +1,2 @@
+ordering_requires = { bool, attribute, attribute_role, type, class, role }
+ordering_requires_same_flavor = false


### PR DESCRIPTION
Order flavors: bool -> class -> role -> attribute_role -> attribute -> type
Order names alphabetically, except `_t` suffix (e.g. treat ssh_t before ssh_exec_t)

Refpolicy findings:

```
postgresql.te:        3: (C): Unordered declaration in require block (class db_database before class db_table) (C-006)
xserver.te:           3: (C): Unordered declaration in require block (class x_screen before class x_gc) (C-006)
irc.if:              19: (C): Unordered declaration in require block (type irc_home_t before type irc_tmp_t) (C-006)
userhelper.if:       25: (C): Unordered declaration in require block (attribute userhelper_type before attribute consolehelper_type) (C-006)
userhelper.if:      149: (C): Unordered declaration in require block (attribute consolehelper_type before class dbus) (C-006)
screen.if:           25: (C): Unordered declaration in require block (attribute screen_domain before attribute role screen_roles) (C-006)
openoffice.if:      107: (C): Unordered declaration in require block (type ooffice_t before class dbus) (C-006)
firewallgui.if:      15: (C): Unordered declaration in require block (type firewallgui_t before class dbus) (C-006)
gift.if:             19: (C): Unordered declaration in require block (type giftd_exec_t before type gift_tmpfs_t) (C-006)
wine.if:             19: (C): Unordered declaration in require block (type wine_exec_t before type wine_t) (C-006)
games.if:            19: (C): Unordered declaration in require block (type games_exec_t before type games_tmp_t) (C-006)
games.if:            92: (C): Unordered declaration in require block (type games_t before class dbus) (C-006)
vmware.if:           19: (C): Unordered declaration in require block (type vmware_file_t before type vmware_conf_t) (C-006)
mozilla.if:          19: (C): Unordered declaration in require block (type mozilla_home_t before type mozilla_tmp_t) (C-006)
mozilla.if:          91: (C): Unordered declaration in require block (type mozilla_plugin_rw_t before type mozilla_plugin_config_t) (C-006)
mozilla.if:         403: (C): Unordered declaration in require block (type mozilla_t before class dbus) (C-006)
mozilla.if:         424: (C): Unordered declaration in require block (type mozilla_plugin_t before class dbus) (C-006)
qemu.if:            314: (C): Unordered declaration in require block (type unconfined_qemu_t before type qemu_exec_t) (C-006)
gpg.if:              19: (C): Unordered declaration in require block (attribute role gpg_roles before attribute role gpg_agent_roles) (C-006)
gpg.if:             211: (C): Unordered declaration in require block (type gpg_secret_t before type gpg_runtime_t) (C-006)
gpg.if:             310: (C): Unordered declaration in require block (type gpg_pinentry_t before class dbus) (C-006)
java.if:             19: (C): Unordered declaration in require block (type java_exec_t before type java_tmp_t) (C-006)
java.if:             82: (C): Unordered declaration in require block (type java_exec_t before type java_tmp_t) (C-006)
java.if:            185: (C): Unordered declaration in require block (type unconfined_java_t before type java_exec_t) (C-006)
telepathy.if:        14: (C): Unordered declaration in require block (attribute telepathy_executable before attribute telepathy_tmp_content) (C-006)
telepathy.if:        60: (C): Unordered declaration in require block (attribute telepathy_domain before attribute telepathy_tmp_content) (C-006)
telepathy.if:       158: (C): Unordered declaration in require block (type telepathy_gabble_t before class dbus) (C-006)
telepathy.if:       179: (C): Unordered declaration in require block (type telepathy_mission_control_t before class dbus) (C-006)
xscreensaver.if:     19: (C): Unordered declaration in require block (attribute role xscreensaver_roles before attribute role xscreensaver_helper_roles) (C-006)
thunderbird.if:      19: (C): Unordered declaration in require block (type thunderbird_home_t before type thunderbird_tmpfs_t) (C-006)
evolution.if:        19: (C): Unordered declaration in require block (type evolution_home_t before type evolution_alarm_t) (C-006)
evolution.if:       180: (C): Unordered declaration in require block (type evolution_t before class dbus) (C-006)
evolution.if:       201: (C): Unordered declaration in require block (type evolution_alarm_t before class dbus) (C-006)
wm.if:              143: (C): Unordered declaration in require block (type $1_wm_t before class dbus) (C-006)
pulseaudio.if:       19: (C): Unordered declaration in require block (type pulseaudio_home_t before type pulseaudio_tmpfs_t) (C-006)
pulseaudio.if:      200: (C): Unordered declaration in require block (type pulseaudio_runtime_t before type pulseaudio_tmp_t) (C-006)
pulseaudio.if:      220: (C): Unordered declaration in require block (type pulseaudio_t before class dbus) (C-006)
chromium.if:         19: (C): Unordered declaration in require block (type chromium_sandbox_t before type chromium_naclhelper_t) (C-006)
gnome.if:            25: (C): Unordered declaration in require block (attribute gnomedomain before attribute gkeyringd_domain) (C-006)
gnome.if:           204: (C): Unordered declaration in require block (type gconfd_t before type gconf_tmp_t) (C-006)
gnome.if:           647: (C): Unordered declaration in require block (type gconfd_t before class dbus) (C-006)
gnome.if:           674: (C): Unordered declaration in require block (type $1_gkeyringd_t before class dbus) (C-006)
gnome.if:           695: (C): Unordered declaration in require block (attribute gkeyringd_domain before class dbus) (C-006)
tvtime.if:           19: (C): Unordered declaration in require block (type tvtime_exec_t before type tvtime_tmp_t) (C-006)
wireshark.if:        19: (C): Unordered declaration in require block (type wireshark_home_t before type wireshark_tmp_t) (C-006)
uml.if:              19: (C): Unordered declaration in require block (type uml_rw_t before type uml_tmp_t) (C-006)
cpufreqselector.if:  15: (C): Unordered declaration in require block (type cpufreqselector_t before class dbus) (C-006)
mplayer.if:          19: (C): Unordered declaration in require block (type mplayer_home_t before type mplayer_t) (C-006)
sigrok.if:           19: (C): Unordered declaration in require block (type sigrok_exec_t before attribute role sigrok_roles) (C-006)
logging.if:         289: (C): Unordered declaration in require block (type audisp_t before role system_r) (C-006)
logging.if:         441: (C): Unordered declaration in require block (type syslogd_unit_t before class service) (C-006)
logging.if:         460: (C): Unordered declaration in require block (type syslogd_unit_t before class service) (C-006)
logging.if:         640: (C): Unordered declaration in require block (type syslogd_runtime_t before type devlog_t) (C-006)
logging.if:        1282: (C): Unordered declaration in require block (type auditd_runtime_t before type auditd_initrc_exec_t) (C-006)
logging.if:        1326: (C): Unordered declaration in require block (type syslogd_t before type klogd_t) (C-006)
iptables.if:        196: (C): Unordered declaration in require block (type iptables_unit_t before class service) (C-006)
iptables.if:        215: (C): Unordered declaration in require block (type iptables_unit_t before class service) (C-006)
iptables.if:        242: (C): Unordered declaration in require block (type iptables_initrc_exec_t before type iptables_conf_t) (C-006)
lvm.if:             229: (C): Unordered declaration in require block (type lvm_unit_t before type lvm_etc_t) (C-006)
libraries.if:        79: (C): Unordered declaration in require block (type lib_t before type ld_so_t) (C-006)
libraries.if:       124: (C): Unordered declaration in require block (type lib_t before type ld_so_t) (C-006)
libraries.if:       146: (C): Unordered declaration in require block (type lib_t before type ld_so_t) (C-006)
libraries.if:       166: (C): Unordered declaration in require block (type lib_t before type ld_so_t) (C-006)
mount.if:           119: (C): Unordered declaration in require block (type unconfined_mount_t before type mount_exec_t) (C-006)
sysnetwork.if:      209: (C): Unordered declaration in require block (type dhcpc_t before class dbus) (C-006)
locallogin.if:      147: (C): Unordered declaration in require block (type sulogin_exec_t before type sulogin_t) (C-006)
ipsec.if:            69: (C): Unordered declaration in require block (type racoon_t before type ipsec_runtime_t) (C-006)
ipsec.if:           182: (C): Unordered declaration in require block (type ipsec_mgmt_t before class dbus) (C-006)
ipsec.if:           391: (C): Unordered declaration in require block (type ipsec_initrc_exec_t before type ipsec_conf_file_t) (C-006)
init.if:             74: (C): Unordered declaration in require block (type initrc_t before attribute init_script_file_type) (C-006)
init.if:            129: (C): Unordered declaration in require block (attribute init_script_file_type before attribute init_run_all_scripts_domain) (C-006)
init.if:            171: (C): Unordered declaration in require block (type init_t before role system_r) (C-006)
init.if:            255: (C): Unordered declaration in require block (type init_t before role system_r) (C-006)
init.if:            328: (C): Unordered declaration in require block (type initrc_t before role system_r) (C-006)
init.if:            520: (C): Unordered declaration in require block (type initrc_t before role system_r) (C-006)
init.if:           1189: (C): Unordered declaration in require block (type init_t before class service) (C-006)
init.if:           1208: (C): Unordered declaration in require block (type init_t before class service) (C-006)
init.if:           1228: (C): Unordered declaration in require block (type init_t before class dbus) (C-006)
init.if:           1561: (C): Unordered declaration in require block (type initctl_t before type init_t) (C-006)
init.if:           1714: (C): Unordered declaration in require block (type initrc_t before attribute init_script_file_type) (C-006)
init.if:           1797: (C): Unordered declaration in require block (type initrc_exec_t before class service) (C-006)
init.if:           1822: (C): Unordered declaration in require block (type initrc_t before attribute initrc_transition_domain) (C-006)
init.if:           1862: (C): Unordered declaration in require block (type initrc_exec_t before class service) (C-006)
init.if:           1956: (C): Unordered declaration in require block (attribute init_script_file_type before role system_r) (C-006)
init.if:           1978: (C): Unordered declaration in require block (attribute init_script_file_type before class service) (C-006)
init.if:           2445: (C): Unordered declaration in require block (type initrc_t before class dbus) (C-006)
init.if:           2465: (C): Unordered declaration in require block (type initrc_t before class dbus) (C-006)
init.if:           3224: (C): Unordered declaration in require block (type systemd_unit_t before class service) (C-006)
init.if:           3243: (C): Unordered declaration in require block (type systemd_unit_t before class service) (C-006)
init.if:           3262: (C): Unordered declaration in require block (type systemd_unit_t before class service) (C-006)
init.if:           3281: (C): Unordered declaration in require block (type systemd_unit_t before class service) (C-006)
init.if:           3300: (C): Unordered declaration in require block (attribute systemdunit before class service) (C-006)
init.if:           3319: (C): Unordered declaration in require block (attribute systemdunit before class service) (C-006)
init.if:           3339: (C): Unordered declaration in require block (attribute systemdunit before class service) (C-006)
init.if:           3358: (C): Unordered declaration in require block (attribute systemdunit before class service) (C-006)
init.if:           3377: (C): Unordered declaration in require block (attribute systemdunit before class service) (C-006)
xen.if:             319: (C): Unordered declaration in require block (type xm_t before type xenstored_runtime_t) (C-006)
pcmcia.if:           67: (C): Unordered declaration in require block (type cardmgr_t before type cardctl_exec_t) (C-006)
userdomain.if:       26: (C): Unordered declaration in require block (type user_devpts_t before type user_tty_device_t) (C-006)
userdomain.if:      342: (C): Unordered declaration in require block (type user_home_dir_t before type user_cert_t) (C-006)
userdomain.if:      546: (C): Unordered declaration in require block (type $1_t before role $1_r) (C-006)
userdomain.if:     1255: (C): Unordered declaration in require block (attribute admindomain before class passwd) (C-006)
userdomain.if:     1858: (C): Unordered declaration in require block (type user_home_dir_t before type user_home_t) (C-006)
userdomain.if:     1934: (C): Unordered declaration in require block (type user_home_dir_t before type user_home_t) (C-006)
userdomain.if:     2047: (C): Unordered declaration in require block (type user_home_dir_t before type user_home_t) (C-006)
userdomain.if:     2066: (C): Unordered declaration in require block (type user_home_dir_t before type user_home_t) (C-006)
userdomain.if:     2240: (C): Unordered declaration in require block (type user_home_dir_t before type user_home_t) (C-006)
userdomain.if:     2260: (C): Unordered declaration in require block (type user_home_dir_t before type user_home_t) (C-006)
userdomain.if:     2306: (C): Unordered declaration in require block (type user_home_dir_t before type user_home_t) (C-006)
userdomain.if:     2346: (C): Unordered declaration in require block (type user_home_dir_t before type user_home_t) (C-006)
userdomain.if:     2405: (C): Unordered declaration in require block (type user_home_dir_t before type user_home_t) (C-006)
userdomain.if:     2426: (C): Unordered declaration in require block (type user_home_dir_t before type user_home_t) (C-006)
userdomain.if:     2500: (C): Unordered declaration in require block (type user_home_dir_t before type user_home_t) (C-006)
userdomain.if:     2561: (C): Unordered declaration in require block (type user_home_dir_t before type user_home_t) (C-006)
userdomain.if:     3653: (C): Unordered declaration in require block (type user_runtime_root_t before type user_runtime_t) (C-006)
userdomain.if:     3887: (C): Unordered declaration in require block (type user_devpts_t before type user_tty_device_t) (C-006)
userdomain.if:     4175: (C): Unordered declaration in require block (type user_home_dir_t before type user_home_t) (C-006)
userdomain.if:     4586: (C): Unordered declaration in require block (attribute userdomain before class dbus) (C-006)
selinuxutil.if:     713: (C): Unordered declaration in require block (type selinux_config_t before type default_context_t) (C-006)
selinuxutil.if:     733: (C): Unordered declaration in require block (type selinux_config_t before type default_context_t) (C-006)
selinuxutil.if:     753: (C): Unordered declaration in require block (type selinux_config_t before type default_context_t) (C-006)
selinuxutil.if:     774: (C): Unordered declaration in require block (type selinux_config_t before type default_context_t) (C-006)
selinuxutil.if:     796: (C): Unordered declaration in require block (type selinux_config_t before type default_context_t) (C-006)
selinuxutil.if:     816: (C): Unordered declaration in require block (type selinux_config_t before type file_context_t) (C-006)
selinuxutil.if:     838: (C): Unordered declaration in require block (type selinux_config_t before type file_context_t) (C-006)
selinuxutil.if:     859: (C): Unordered declaration in require block (type selinux_config_t before type policy_config_t) (C-006)
selinuxutil.if:     880: (C): Unordered declaration in require block (type selinux_config_t before type policy_config_t) (C-006)
selinuxutil.if:     924: (C): Unordered declaration in require block (type selinux_config_t before type policy_config_t) (C-006)
selinuxutil.if:     946: (C): Unordered declaration in require block (type selinux_config_t before type policy_src_t) (C-006)
selinuxutil.if:     968: (C): Unordered declaration in require block (type selinux_config_t before type policy_src_t) (C-006)
systemd.if:          24: (C): Unordered declaration in require block (attribute systemd_user_session_type before attribute systemd_log_parse_env_type) (C-006)
systemd.if:         282: (C): Unordered declaration in require block (type systemd_sessions_runtime_t before type systemd_logind_t) (C-006)
systemd.if:         323: (C): Unordered declaration in require block (type systemd_logind_inhibit_runtime_t before type systemd_logind_t) (C-006)
systemd.if:         344: (C): Unordered declaration in require block (type systemd_logind_t before class dbus) (C-006)
systemd.if:         379: (C): Unordered declaration in require block (type systemd_logind_t before class service) (C-006)
systemd.if:         436: (C): Unordered declaration in require block (type systemd_hostnamed_t before class dbus) (C-006)
systemd.if:         674: (C): Unordered declaration in require block (type systemd_networkd_unit_t before class service) (C-006)
systemd.if:         693: (C): Unordered declaration in require block (type systemd_networkd_unit_t before class service) (C-006)
systemd.if:         712: (C): Unordered declaration in require block (type systemd_networkd_unit_t before class service) (C-006)
systemd.if:         843: (C): Unordered declaration in require block (type power_unit_t before class service) (C-006)
systemd.if:         862: (C): Unordered declaration in require block (type power_unit_t before class service) (C-006)
systemd.if:        1036: (C): Unordered declaration in require block (type systemd_resolved_t before class dbus) (C-006)
unconfined.if:       14: (C): Unordered declaration in require block (type unconfined_t before class dbus) (C-006)
unconfined.if:      269: (C): Unordered declaration in require block (type unconfined_t before role unconfined_r) (C-006)
unconfined.if:      556: (C): Unordered declaration in require block (type unconfined_t before class dbus) (C-006)
unconfined.if:      576: (C): Unordered declaration in require block (type unconfined_t before class dbus) (C-006)
unconfined.if:      597: (C): Unordered declaration in require block (type unconfined_t before class dbus) (C-006)
iscsi.if:            53: (C): Unordered declaration in require block (type iscsid_t before type iscsi_var_lib_t) (C-006)
iscsi.if:            99: (C): Unordered declaration in require block (type iscsid_t before type iscsi_lock_t) (C-006)
authlogin.if:       138: (C): Unordered declaration in require block (type var_auth_t before type auth_cache_t) (C-006)
authlogin.if:       395: (C): Unordered declaration in require block (type shadow_t before type auth_cache_t) (C-006)
authlogin.if:      1680: (C): Unordered declaration in require block (attribute can_write_shadow_passwords before attribute can_relabelto_shadow_passwords) (C-006)
bacula.if:           68: (C): Unordered declaration in require block (type bacula_var_lib_t before type bacula_runtime_t) (C-006)
puppet.if:          204: (C): Unordered declaration in require block (type puppetmaster_initrc_exec_t before type puppet_log_t) (C-006)
bcfg2.if:           136: (C): Unordered declaration in require block (type bcfg2_var_lib_t before type bcfg2_runtime_t) (C-006)
vpn.if:             115: (C): Unordered declaration in require block (type vpnc_t before class dbus) (C-006)
mrtg.if:             59: (C): Unordered declaration in require block (type mrtg_runtime_t before type mrtg_initrc_exec_t) (C-006)
portage.if:          66: (C): Unordered declaration in require block (type portage_srcrepo_t before type portage_tmp_t) (C-006)
mcelog.if:           40: (C): Unordered declaration in require block (type mcelog_runtime_t before type mcelog_etc_t) (C-006)
blueman.if:          34: (C): Unordered declaration in require block (type blueman_t before class dbus) (C-006)
quota.if:           179: (C): Unordered declaration in require block (type quota_nld_t before type quota_t) (C-006)
rpm.if:              34: (C): Unordered declaration in require block (type rpm_t before type debuginfo_exec_t) (C-006)
rpm.if:             194: (C): Unordered declaration in require block (type rpm_t before class dbus) (C-006)
rpm.if:             215: (C): Unordered declaration in require block (type rpm_t before class dbus) (C-006)
rpm.if:             236: (C): Unordered declaration in require block (type rpm_script_t before class dbus) (C-006)
rpm.if:             614: (C): Unordered declaration in require block (type rpm_script_t before type rpm_initrc_exec_t) (C-006)
usermanage.if:      196: (C): Unordered declaration in require block (type sysadm_passwd_t before type admin_passwd_exec_t) (C-006)
acct.if:            102: (C): Unordered declaration in require block (type acct_initrc_exec_t before type acct_data_t) (C-006)
netutils.if:        184: (C): Unordered declaration in require block (type ping_t before boolean user_ping) (C-006)
netutils.if:        278: (C): Unordered declaration in require block (type traceroute_t before boolean user_ping) (C-006)
shorewall.if:       164: (C): Unordered declaration in require block (type shorewall_log_t before type shorewall_exec_t) (C-006)
kdump.if:            98: (C): Unordered declaration in require block (type kdumpctl_tmp_t before type kdump_initrc_exec_t) (C-006)
kudzu.if:            84: (C): Unordered declaration in require block (type kudzu_runtime_t before type kudzu_tmp_t) (C-006)
sudo.if:             33: (C): Unordered declaration in require block (type sudo_exec_t before attribute sudodomain) (C-006)
kismet.if:           19: (C): Unordered declaration in require block (type kismet_home_t before type kismet_tmp_t) (C-006)
kismet.if:          284: (C): Unordered declaration in require block (type kismet_var_lib_t before type kismet_runtime_t) (C-006)
certwatch.if:        14: (C): Unordered declaration in require block (type certwatch_exec_t before type certwatch_t) (C-006)
glusterfs.if:        21: (C): Unordered declaration in require block (type glusterd_log_t before type glusterd_tmp_t) (C-006)
privoxy.if:          21: (C): Unordered declaration in require block (type privoxy_log_t before type privoxy_initrc_exec_t) (C-006)
canna.if:            41: (C): Unordered declaration in require block (type canna_var_lib_t before type canna_runtime_t) (C-006)
apcupsd.if:         144: (C): Unordered declaration in require block (type apcupsd_runtime_t before type apcupsd_initrc_exec_t) (C-006)
acpi.if:            160: (C): Unordered declaration in require block (type acpid_log_t before type acpid_lock_t) (C-006)
hal.if:             220: (C): Unordered declaration in require block (type hald_t before class dbus) (C-006)
hal.if:             240: (C): Unordered declaration in require block (type hald_t before class dbus) (C-006)
tor.if:              40: (C): Unordered declaration in require block (type tor_var_log_t before type tor_etc_t) (C-006)
nis.if:             346: (C): Unordered declaration in require block (type ypxfr_t before type ypbind_tmp_t) (C-006)
vhostmd.if:         214: (C): Unordered declaration in require block (type vhostmd_runtime_t before type vhostmd_tmpfs_t) (C-006)
ldap.if:            100: (C): Unordered declaration in require block (type slapd_replog_t before type slapd_lock_t) (C-006)
mysql.if:            98: (C): Unordered declaration in require block (type mysqld_runtime_t before type mysqld_db_t) (C-006)
mysql.if:           408: (C): Unordered declaration in require block (type mysqld_runtime_t before type mysqld_etc_t) (C-006)
fetchmail.if:        21: (C): Unordered declaration in require block (type fetchmail_uidl_cache_t before type fetchmail_runtime_t) (C-006)
dcc.if:             172: (C): Unordered declaration in require block (type dccifd_runtime_t before type dccifd_t) (C-006)
zebra.if:            63: (C): Unordered declaration in require block (type zebra_log_t before type zebra_conf_t) (C-006)
knot.if:             85: (C): Unordered declaration in require block (type knotd_t before type knot_conf_t) (C-006)
bitlbee.if:          41: (C): Unordered declaration in require block (type bitlbee_var_t before type bitlbee_initrc_exec_t) (C-006)
cyphesis.if:         40: (C): Unordered declaration in require block (type cyphesis_runtime_t before type cyphesis_tmp_t) (C-006)
clamav.if:          329: (C): Unordered declaration in require block (type clamd_unit_t before class service) (C-006)
clamav.if:          348: (C): Unordered declaration in require block (type clamd_unit_t before class service) (C-006)
clamav.if:          367: (C): Unordered declaration in require block (type clamd_unit_t before class service) (C-006)
clamav.if:          386: (C): Unordered declaration in require block (type clamd_unit_t before class service) (C-006)
clamav.if:          412: (C): Unordered declaration in require block (type clamd_etc_t before type clamd_tmp_t) (C-006)
dspam.if:            61: (C): Unordered declaration in require block (type dspam_var_lib_t before type dspam_runtime_t) (C-006)
distcc.if:           21: (C): Repeated declaration in require block (type distccd_t) (C-006)
pkcs.if:             21: (C): Unordered declaration in require block (type pkcs_slotd_var_lib_t before type pkcs_slotd_runtime_t) (C-006)
smokeping.if:       156: (C): Unordered declaration in require block (type smokeping_var_lib_t before type smokeping_runtime_t) (C-006)
jabber.if:           61: (C): Unordered declaration in require block (type jabberd_var_lib_t before type jabberd_runtime_t) (C-006)
nscd.if:            107: (C): Unordered declaration in require block (type nscd_runtime_t before class nscd) (C-006)
nscd.if:            139: (C): Unordered declaration in require block (type nscd_runtime_t before class nscd) (C-006)
nscd.if:            224: (C): Unordered declaration in require block (type nscd_t before class nscd) (C-006)
nscd.if:            294: (C): Unordered declaration in require block (type nscd_runtime_t before type nscd_initrc_exec_t) (C-006)
portmap.if:          67: (C): Unordered declaration in require block (type portmap_initrc_exec_t before type portmap_helper_t) (C-006)
asterisk.if:        121: (C): Unordered declaration in require block (type asterisk_spool_t before type asterisk_etc_t) (C-006)
amavis.if:          231: (C): Unordered declaration in require block (type amavis_var_log_t before type amavis_spool_t) (C-006)
nut.if:              21: (C): Unordered declaration in require block (type nut_runtime_t before type nut_conf_t) (C-006)
tpm2.if:             83: (C): Unordered declaration in require block (type tpm2_abrmd_t before class dbus) (C-006)
tpm2.if:            103: (C): Unordered declaration in require block (type tpm2_abrmd_unit_t before class service) (C-006)
tpm2.if:            122: (C): Unordered declaration in require block (type tpm2_abrmd_unit_t before class service) (C-006)
tpm2.if:            141: (C): Unordered declaration in require block (type tpm2_abrmd_unit_t before class service) (C-006)
xserver.if:          20: (C): Unordered declaration in require block (type xserver_tmpfs_t before type user_fonts_t) (C-006)
xserver.if:         140: (C): Unordered declaration in require block (type xserver_tmpfs_t before type xauth_home_t) (C-006)
xserver.if:         299: (C): Unordered declaration in require block (type xserver_t before type xdm_var_run_t) (C-006)
xserver.if:         338: (C): Unordered declaration in require block (type xevent_t before type client_xevent_t) (C-006)
xserver.if:         397: (C): Unordered declaration in require block (attribute xproperty_type before attribute input_xevent_type) (C-006)
xserver.if:         439: (C): Unordered declaration in require block (type xdm_tmp_t before type xauth_home_t) (C-006)
xserver.if:         845: (C): Unordered declaration in require block (type xdm_t before class dbus) (C-006)
xserver.if:        1588: (C): Unordered declaration in require block (type xserver_t before class x_device) (C-006)
glance.if:          239: (C): Unordered declaration in require block (type glance_registry_t before type glance_api_t) (C-006)
dhcp.if:             79: (C): Unordered declaration in require block (type dhcpd_state_t before type dhcpd_runtime_t) (C-006)
rhsmcertd.if:       231: (C): Unordered declaration in require block (type rhsmcertd_t before class dbus) (C-006)
rhsmcertd.if:       253: (C): Unordered declaration in require block (type rhsmcertd_t before class dbus) (C-006)
rhsmcertd.if:       280: (C): Unordered declaration in require block (type rhsmcertd_var_lib_t before type rhsmcertd_runtime_t) (C-006)
redis.if:            21: (C): Unordered declaration in require block (type redis_var_lib_t before type redis_log_t) (C-006)
gnomeclock.if:       61: (C): Unordered declaration in require block (type gnomeclock_t before class dbus) (C-006)
gnomeclock.if:       83: (C): Unordered declaration in require block (type gnomeclock_t before class dbus) (C-006)
nsd.if:              21: (C): Unordered declaration in require block (type nsd_runtime_t before type nsd_initrc_exec_t) (C-006)
uucp.if:            101: (C): Unordered declaration in require block (type uucpd_spool_t before type uucpd_ro_t) (C-006)
postgresql.if:       19: (C): Unordered declaration in require block (class db_schema before class db_table) (C-006)
postgresql.if:      255: (C): Unordered declaration in require block (attribute sepgsql_procedure_type before attribute sepgsql_trusted_procedure_type) (C-006)
postgresql.if:      426: (C): Unordered declaration in require block (type postgresql_runtime_t before type postgresql_tmp_t) (C-006)
postgresql.if:      448: (C): Unordered declaration in require block (class db_schema before class db_table) (C-006)
postgresql.if:      564: (C): Unordered declaration in require block (type postgresql_runtime_t before type postgresql_tmp_t) (C-006)
couchdb.if:          97: (C): Unordered declaration in require block (type couchdb_var_lib_t before type couchdb_runtime_t) (C-006)
ddclient.if:         67: (C): Unordered declaration in require block (type ddclient_var_lib_t before type ddclient_tmp_t) (C-006)
modemmanager.if:     34: (C): Unordered declaration in require block (type modemmanager_t before class dbus) (C-006)
dante.if:            21: (C): Unordered declaration in require block (type dante_runtime_t before type dante_initrc_exec_t) (C-006)
soundserver.if:      21: (C): Unordered declaration in require block (type soundd_initrc_exec_t before type soundd_tmp_t) (C-006)
dbus.if:             14: (C): Unordered declaration in require block (type system_dbusd_t before class dbus) (C-006)
dbus.if:             61: (C): Unordered declaration in require block (type system_dbusd_t before type dbusd_exec_t) (C-006)
dbus.if:            128: (C): Unordered declaration in require block (type system_dbusd_var_lib_t before class dbus) (C-006)
dbus.if:            160: (C): Unordered declaration in require block (attribute session_bus_type before class dbus) (C-006)
dbus.if:            186: (C): Unordered declaration in require block (type $1_dbusd_t before class dbus) (C-006)
dbus.if:            206: (C): Unordered declaration in require block (attribute session_bus_type before attribute dbusd_session_bus_client) (C-006)
dbus.if:            238: (C): Unordered declaration in require block (type $1_dbusd_t before class dbus) (C-006)
dbus.if:            265: (C): Unordered declaration in require block (attribute session_bus_type before class dbus) (C-006)
dbus.if:            291: (C): Unordered declaration in require block (type $1_dbusd_t before class dbus) (C-006)
dbus.if:            450: (C): Unordered declaration in require block (type system_dbusd_t before class dbus) (C-006)
dbus.if:            469: (C): Unordered declaration in require block (type system_dbusd_t before class dbus) (C-006)
dbus.if:            488: (C): Unordered declaration in require block (type system_dbusd_t before class dbus) (C-006)
dbus.if:            513: (C): Unordered declaration in require block (type system_dbusd_t before role system_r) (C-006)
pacemaker.if:        21: (C): Unordered declaration in require block (type pacemaker_var_lib_t before type pacemaker_runtime_t) (C-006)
pyicqt.if:           21: (C): Unordered declaration in require block (type pyicqt_spool_t before type pyicqt_runtime_t) (C-006)
psad.if:            236: (C): Unordered declaration in require block (type psad_var_log_t before type psad_initrc_exec_t) (C-006)
dnssectrigger.if:    21: (C): Unordered declaration in require block (type dnssec_triggerd_initrc_exec_t before type dnssec_trigger_conf_t) (C-006)
openhpi.if:          21: (C): Unordered declaration in require block (type openhpid_var_lib_t before type openhpid_runtime_t) (C-006)
qpid.if:            172: (C): Unordered declaration in require block (type qpidd_var_lib_t before type qpidd_runtime_t) (C-006)
minissdpd.if:        40: (C): Unordered declaration in require block (type minissdpd_initrc_exec_t before type minissdpd_conf_t) (C-006)
abrt.if:            108: (C): Unordered declaration in require block (type abrt_t before class dbus) (C-006)
abrt.if:            281: (C): Unordered declaration in require block (type abrt_var_log_t before type abrt_retrace_cache_t) (C-006)
apache.if:           15: (C): Unordered declaration in require block (attribute httpdcontent before attribute httpd_exec_scripts) (C-006)
apache.if:          119: (C): Unordered declaration in require block (type httpd_user_script_exec_t before type httpd_user_ra_content_t) (C-006)
apache.if:          400: (C): Unordered declaration in require block (type httpd_unit_t before class service) (C-006)
apache.if:          494: (C): Unordered declaration in require block (attribute httpdcontent before attribute httpd_script_exec_type) (C-006)
apache.if:          536: (C): Unordered declaration in require block (attribute httpdcontent before attribute httpd_script_exec_type) (C-006)
apache.if:         1204: (C): Unordered declaration in require block (type httpd_user_content_rw_t before type httpd_user_content_ra_t) (C-006)
apache.if:         1340: (C): Unordered declaration in require block (attribute httpdcontent before attribute httpd_script_exec_type) (C-006)
cgroup.if:          142: (C): Unordered declaration in require block (type cgred_runtime_t before type cgred_t) (C-006)
cgroup.if:          168: (C): Unordered declaration in require block (type cgred_t before type cgconfig_t) (C-006)
sanlock.if:          99: (C): Unordered declaration in require block (type sanlock_runtime_t before type sanlock_log_t) (C-006)
rpcbind.if:         155: (C): Unordered declaration in require block (type rpcbind_var_lib_t before type rpcbind_runtime_t) (C-006)
kerberos.if:         52: (C): Unordered declaration in require block (type krb5kdc_conf_t before type krb5_host_rcache_t) (C-006)
kerberos.if:        440: (C): Unordered declaration in require block (type krb5kdc_t before type kerberos_initrc_exec_t) (C-006)
ctdb.if:             35: (C): Unordered declaration in require block (type ctdbd_runtime_t before type ctdbd_tmp_t) (C-006)
ctdb.if:             61: (C): Unordered declaration in require block (type ctdbd_initrc_exec_t before type ctdbd_tmp_t) (C-006)
oident.if:          108: (C): Unordered declaration in require block (type oidentd_initrc_exec_t before type oidentd_config_t) (C-006)
cyrus.if:            61: (C): Unordered declaration in require block (type cyrus_var_lib_t before type cyrus_runtime_t) (C-006)
ksmtuned.if:         59: (C): Unordered declaration in require block (type ksmtuned_runtime_t before type ksmtuned_initrc_exec_t) (C-006)
ccs.if:              99: (C): Unordered declaration in require block (type cluster_conf_t before type ccs_var_lib_t) (C-006)
mailman.if:          55: (C): Unordered declaration in require block (type mailman_mail_exec_t before type mailman_mail_t) (C-006)
mailman.if:         102: (C): Unordered declaration in require block (type mailman_cgi_exec_t before type mailman_cgi_t) (C-006)
mailman.if:         338: (C): Unordered declaration in require block (type mailman_queue_exec_t before type mailman_queue_t) (C-006)
realmd.if:           34: (C): Unordered declaration in require block (type realmd_t before class dbus) (C-006)
chronyd.if:         255: (C): Unordered declaration in require block (type chronyd_unit_t before class service) (C-006)
chronyd.if:         274: (C): Unordered declaration in require block (type chronyd_unit_t before class service) (C-006)
chronyd.if:         293: (C): Unordered declaration in require block (type chronyd_unit_t before class service) (C-006)
chronyd.if:         339: (C): Unordered declaration in require block (type chronyd_var_log_t before type chronyd_runtime_t) (C-006)
nagios.if:          195: (C): Unordered declaration in require block (type nrpe_t before type nagios_initrc_exec_t) (C-006)
fail2ban.if:        260: (C): Unordered declaration in require block (type fail2ban_log_t before type fail2ban_tmp_t) (C-006)
policykit.if:        15: (C): Unordered declaration in require block (type policykit_t before class dbus) (C-006)
policykit.if:        36: (C): Unordered declaration in require block (type policykit_auth_t before class dbus) (C-006)
cups.if:             88: (C): Unordered declaration in require block (type cupsd_t before class dbus) (C-006)
cups.if:            167: (C): Unordered declaration in require block (type cupsd_config_t before class dbus) (C-006)
cups.if:            353: (C): Unordered declaration in require block (type cupsd_lpd_tmp_t before type cupsd_etc_t) (C-006)
snort.if:            40: (C): Unordered declaration in require block (type snort_runtime_t before type snort_log_t) (C-006)
oddjob.if:           58: (C): Unordered declaration in require block (type oddjob_t before class dbus) (C-006)
aisexec.if:          80: (C): Unordered declaration in require block (type aisexec_var_log_t before type aisexec_runtime_t) (C-006)
isns.if:             21: (C): Unordered declaration in require block (type isnsd_var_lib_t before type isnsd_runtime_t) (C-006)
openvswitch.if:      59: (C): Unordered declaration in require block (type openvswitch_initrc_exec_t before type openvswitch_conf_t) (C-006)
denyhosts.if:        58: (C): Unordered declaration in require block (type denyhosts_var_log_t before type denyhosts_initrc_exec_t) (C-006)
resmgr.if:           15: (C): Unordered declaration in require block (type resmgrd_runtime_t before type resmgrd_t) (C-006)
resmgr.if:           41: (C): Unordered declaration in require block (type resmgrd_runtime_t before type resmgrd_etc_t) (C-006)
vdagent.if:          90: (C): Unordered declaration in require block (type vdagent_runtime_t before type vdagent_t) (C-006)
vdagent.if:         116: (C): Unordered declaration in require block (type vdagentd_initrc_exec_t before type vdagent_log_t) (C-006)
nslcd.if:            97: (C): Unordered declaration in require block (type nslcd_runtime_t before type nslcd_conf_t) (C-006)
squid.if:           215: (C): Unordered declaration in require block (type squid_runtime_t before type squid_tmpfs_t) (C-006)
afs.if:              96: (C): Unordered declaration in require block (type afs_initrc_exec_t before type afs_dbdir_t) (C-006)
postfixpolicyd.if:   21: (C): Unordered declaration in require block (type postfix_policyd_runtime_t before type postfix_policyd_initrc_exec_t) (C-006)
razor.if:            52: (C): Unordered declaration in require block (type razor_home_t before type razor_tmp_t) (C-006)
razor.if:            83: (C): Unordered declaration in require block (type system_razor_t before type razor_exec_t) (C-006)
rabbitmq.if:         14: (C): Unordered declaration in require block (type rabbitmq_epmd_exec_t before type rabbitmq_beam_t) (C-006)
rabbitmq.if:         42: (C): Unordered declaration in require block (type rabbitmq_epmd_t before type rabbitmq_beam_t) (C-006)
cron.if:             60: (C): Unordered declaration in require block (type user_cron_spool_t before type crond_t) (C-006)
cron.if:            141: (C): Unordered declaration in require block (type unconfined_cronjob_t before type crontab_t) (C-006)
cron.if:            222: (C): Unordered declaration in require block (type crontab_exec_t before type admin_crontab_t) (C-006)
cron.if:            337: (C): Unordered declaration in require block (type system_cronjob_t before type crond_exec_t) (C-006)
cron.if:            664: (C): Unordered declaration in require block (type system_cronjob_t before type anacron_exec_t) (C-006)
cron.if:            955: (C): Unordered declaration in require block (type cronjob_t before type crond_initrc_exec_t) (C-006)
tgtd.if:             78: (C): Unordered declaration in require block (type tgtd_var_lib_t before type tgtd_runtime_t) (C-006)
fprintd.if:          34: (C): Unordered declaration in require block (type fprintd_t before class dbus) (C-006)
spamassassin.if:     19: (C): Unordered declaration in require block (type spamc_exec_t before type spamc_tmp_t) (C-006)
spamassassin.if:     58: (C): Unordered declaration in require block (type spamd_update_exec_t before type spamd_update_t) (C-006)
spamassassin.if:    116: (C): Unordered declaration in require block (type spamassassin_unit_t before class service) (C-006)
spamassassin.if:    136: (C): Unordered declaration in require block (type spamassassin_unit_t before class service) (C-006)
spamassassin.if:    444: (C): Unordered declaration in require block (type spamd_var_lib_t before type spamd_runtime_t) (C-006)
plymouthd.if:       291: (C): Unordered declaration in require block (type plymouthd_var_lib_t before type plymouthd_runtime_t) (C-006)
rshd.if:             14: (C): Unordered declaration in require block (type rshd_exec_t before type rshd_t) (C-006)
cachefilesd.if:      21: (C): Unordered declaration in require block (type cachefilesd_initrc_exec_t before type cachefilesd_cache_t) (C-006)
l2tp.if:             54: (C): Unordered declaration in require block (type l2tpd_runtime_t before type l2tpd_tmp_t) (C-006)
l2tp.if:             81: (C): Unordered declaration in require block (type l2tpd_runtime_t before type l2tp_conf_t) (C-006)
bluetooth.if:        19: (C): Unordered declaration in require block (type bluetooth_helper_exec_t before type bluetooth_helper_tmp_t) (C-006)
bluetooth.if:       122: (C): Unordered declaration in require block (type bluetooth_t before class dbus) (C-006)
bluetooth.if:       169: (C): Unordered declaration in require block (type bluetooth_var_lib_t before type bluetooth_runtime_t) (C-006)
minidlna.if:         21: (C): Unordered declaration in require block (type minidlna_runtime_t before type minidlna_initrc_exec_t) (C-006)
monop.if:            21: (C): Unordered declaration in require block (type monopd_share_t before type monopd_etc_t) (C-006)
hadoop.if:           14: (C): Unordered declaration in require block (attribute hadoop_initrc_domain before attribute hadoop_init_script_file) (C-006)
hadoop.if:          108: (C): Unordered declaration in require block (type zookeeper_t before type hadoop_home_t) (C-006)
hadoop.if:          425: (C): Unordered declaration in require block (attribute hadoop_pid_file before attribute hadoop_lock_file) (C-006)
virt.if:             14: (C): Unordered declaration in require block (attribute virt_image_type before attribute virt_domain) (C-006)
virt.if:            253: (C): Unordered declaration in require block (attribute virt_domain before attribute role virt_domain_roles) (C-006)
virt.if:            320: (C): Unordered declaration in require block (attribute svirt_lxc_domain before attribute role svirt_lxc_domain_roles) (C-006)
virt.if:            363: (C): Unordered declaration in require block (type virtd_t before type virt_runtime_t) (C-006)
virt.if:           1139: (C): Unordered declaration in require block (attribute virt_image_type before attribute virt_tmpfs_type) (C-006)
tuned.if:           117: (C): Unordered declaration in require block (type tuned_runtime_t before type tuned_initrc_exec_t) (C-006)
rhcs.if:             14: (C): Unordered declaration in require block (attribute cluster_pid before attribute cluster_tmpfs) (C-006)
rhcs.if:            216: (C): Unordered declaration in require block (type fenced_runtime_t before type fenced_t) (C-006)
rhcs.if:            357: (C): Unordered declaration in require block (attribute cluster_domain before attribute cluster_tmpfs) (C-006)
rhcs.if:            465: (C): Unordered declaration in require block (attribute cluster_pid before attribute cluster_tmpfs) (C-006)
prelude.if:         118: (C): Unordered declaration in require block (type prelude_spool_t before type prelude_lml_runtime_t) (C-006)
sasl.if:             40: (C): Unordered declaration in require block (type saslauthd_runtime_t before type saslauthd_initrc_exec_t) (C-006)
radius.if:           21: (C): Unordered declaration in require block (type radiusd_log_t before type radiusd_etc_rw_t) (C-006)
boinc.if:            21: (C): Unordered declaration in require block (type boinc_project_t before type boinc_log_t) (C-006)
munin.if:            14: (C): Unordered declaration in require block (attribute munin_plugin_domain before attribute munin_plugin_tmp_content) (C-006)
munin.if:            56: (C): Unordered declaration in require block (type munin_runtime_t before type munin_t) (C-006)
munin.if:           163: (C): Unordered declaration in require block (attribute munin_plugin_domain before attribute munin_plugin_tmp_content) (C-006)
sendmail.if:        338: (C): Unordered declaration in require block (type sendmail_log_t before type sendmail_tmp_t) (C-006)
snmp.if:            162: (C): Unordered declaration in require block (type snmpd_log_t before type snmpd_initrc_exec_t) (C-006)
mpd.if:             322: (C): Unordered declaration in require block (type mpd_initrc_exec_t before type mpd_etc_t) (C-006)
rpc.if:             361: (C): Unordered declaration in require block (type rpcd_initrc_exec_t before type exports_t) (C-006)
inn.if:             227: (C): Unordered declaration in require block (type news_spool_t before type innd_var_lib_t) (C-006)
quantum.if:          21: (C): Unordered declaration in require block (type quantum_var_lib_t before type quantum_tmp_t) (C-006)
i18n_input.if:       21: (C): Unordered declaration in require block (type i18n_input_runtime_t before type i18n_input_log_t) (C-006)
consolekit.if:       34: (C): Unordered declaration in require block (type consolekit_t before class dbus) (C-006)
polipo.if:           19: (C): Unordered declaration in require block (type polipo_session_t before type polipo_exec_t) (C-006)
polipo.if:          120: (C): Unordered declaration in require block (type polipo_system_t before type polipo_initrc_exec_t) (C-006)
ulogd.if:           121: (C): Unordered declaration in require block (type ulogd_var_log_t before type ulogd_initrc_exec_t) (C-006)
firewalld.if:        34: (C): Unordered declaration in require block (type firewalld_t before class dbus) (C-006)
firewalld.if:        99: (C): Unordered declaration in require block (type firewalld_initrc_exec_t before type firewalld_etc_rw_t) (C-006)
gssproxy.if:        151: (C): Unordered declaration in require block (type gssproxy_var_lib_t before type gssproxy_run_t) (C-006)
nessus.if:           21: (C): Unordered declaration in require block (type nessusd_initrc_exec_t before type nessusd_etc_t) (C-006)
systemtap.if:        21: (C): Unordered declaration in require block (type stapserver_runtime_t before type stapserver_initrc_exec_t) (C-006)
certmaster.if:      118: (C): Unordered declaration in require block (type certmaster_var_lib_t before type certmaster_etc_rw_t) (C-006)
ntp.if:              94: (C): Unordered declaration in require block (type ntpd_t before class dbus) (C-006)
ntp.if:             213: (C): Unordered declaration in require block (type ntpd_unit_t before class service) (C-006)
ntp.if:             234: (C): Unordered declaration in require block (type ntpd_unit_t before class service) (C-006)
ntp.if:             255: (C): Unordered declaration in require block (type ntpd_unit_t before class service) (C-006)
ntp.if:             282: (C): Unordered declaration in require block (type ntpd_log_t before type ntpd_key_t) (C-006)
ircd.if:             21: (C): Unordered declaration in require block (type ircd_initrc_exec_t before type ircd_etc_t) (C-006)
gpm.if:              15: (C): Unordered declaration in require block (type gpmctl_t before type gpm_t) (C-006)
corosync.if:        137: (C): Unordered declaration in require block (type corosync_var_log_t before type corosync_runtime_t) (C-006)
samba.if:            51: (C): Unordered declaration in require block (type samba_var_t before type nmbd_t) (C-006)
samba.if:           639: (C): Unordered declaration in require block (type winbind_runtime_t before type samba_runtime_t) (C-006)
samba.if:           659: (C): Unordered declaration in require block (type winbind_runtime_t before type smbd_runtime_t) (C-006)
samba.if:           685: (C): Unordered declaration in require block (type smbd_tmp_t before type samba_log_t) (C-006)
dnsmasq.if:          15: (C): Unordered declaration in require block (type dnsmasq_exec_t before type dnsmasq_t) (C-006)
dnsmasq.if:         268: (C): Unordered declaration in require block (type dnsmasq_runtime_t before type dnsmasq_initrc_exec_t) (C-006)
ifplugd.if:         117: (C): Unordered declaration in require block (type ifplugd_runtime_t before type ifplugd_initrc_exec_t) (C-006)
bind.if:            151: (C): Unordered declaration in require block (type named_zone_t before type dnssec_t) (C-006)
bind.if:            225: (C): Unordered declaration in require block (type named_conf_t before type named_cache_t) (C-006)
bind.if:            350: (C): Unordered declaration in require block (type named_log_t before type named_cache_t) (C-006)
pingd.if:            79: (C): Unordered declaration in require block (type pingd_modules_t before type pingd_initrc_exec_t) (C-006)
mongodb.if:          21: (C): Unordered declaration in require block (type mongod_var_lib_t before type mongod_runtime_t) (C-006)
zabbix.if:          138: (C): Unordered declaration in require block (type zabbix_runtime_t before type zabbix_initrc_exec_t) (C-006)
ppp.if:             461: (C): Unordered declaration in require block (type pppd_log_t before type pppd_lock_t) (C-006)
exim.if:            301: (C): Unordered declaration in require block (type exim_spool_t before type exim_log_t) (C-006)
procmail.if:         14: (C): Unordered declaration in require block (type procmail_exec_t before type procmail_t) (C-006)
bird.if:             21: (C): Unordered declaration in require block (type bird_runtime_t before type bird_initrc_exec_t) (C-006)
dictd.if:            21: (C): Unordered declaration in require block (type dictd_var_lib_t before type dictd_runtime_t) (C-006)
portreserve.if:     103: (C): Unordered declaration in require block (type portreserve_runtime_t before type portreserve_initrc_exec_t) (C-006)
arpwatch.if:        138: (C): Unordered declaration in require block (type arpwatch_initrc_exec_t before type arpwatch_data_t) (C-006)
ntop.if:             21: (C): Unordered declaration in require block (type ntop_runtime_t before type ntop_initrc_exec_t) (C-006)
postgrey.if:         15: (C): Unordered declaration in require block (type postgrey_runtime_t before type postgrey_t) (C-006)
postgrey.if:         61: (C): Unordered declaration in require block (type postgrey_var_lib_t before type postgrey_runtime_t) (C-006)
roundup.if:          21: (C): Unordered declaration in require block (type roundup_var_lib_t before type roundup_runtime_t) (C-006)
smartmon.if:         40: (C): Unordered declaration in require block (type fsdaemon_var_lib_t before type fsdaemon_initrc_exec_t) (C-006)
setroubleshoot.if:   15: (C): Unordered declaration in require block (type setroubleshootd_t before type setroubleshoot_runtime_t) (C-006)
setroubleshoot.if:   37: (C): Unordered declaration in require block (type setroubleshootd_t before type setroubleshoot_runtime_t) (C-006)
setroubleshoot.if:   75: (C): Unordered declaration in require block (type setroubleshootd_t before class dbus) (C-006)
setroubleshoot.if:   96: (C): Unordered declaration in require block (type setroubleshootd_t before class dbus) (C-006)
setroubleshoot.if:  117: (C): Unordered declaration in require block (type setroubleshoot_fixit_t before class dbus) (C-006)
setroubleshoot.if:  144: (C): Unordered declaration in require block (type setroubleshootd_t before type setroubleshoot_var_log_t) (C-006)
certmonger.if:       34: (C): Unordered declaration in require block (type certmonger_t before class dbus) (C-006)
certmonger.if:      157: (C): Unordered declaration in require block (type certmonger_var_lib_t before type certmonger_runtime_t) (C-006)
pyzor.if:            19: (C): Unordered declaration in require block (type pyzor_home_t before type pyzor_tmp_t) (C-006)
pyzor.if:            68: (C): Unordered declaration in require block (type pyzor_exec_t before type pyzor_t) (C-006)
pyzor.if:           113: (C): Unordered declaration in require block (type pyzord_log_t before type pyzor_var_lib_t) (C-006)
obex.if:             81: (C): Unordered declaration in require block (type obex_t before class dbus) (C-006)
tcpd.if:             39: (C): Unordered declaration in require block (type tcpd_t before role system_r) (C-006)
varnishd.if:        190: (C): Unordered declaration in require block (type varnishd_var_lib_t before type varnishd_etc_t) (C-006)
likewise.if:         72: (C): Unordered declaration in require block (type lsassd_var_socket_t before type lsassd_t) (C-006)
likewise.if:         98: (C): Unordered declaration in require block (type likewise_initrc_exec_t before type likewise_etc_t) (C-006)
rtkit.if:            34: (C): Unordered declaration in require block (type rtkit_daemon_t before class dbus) (C-006)
pads.if:             21: (C): Unordered declaration in require block (type pads_runtime_t before type pads_initrc_exec_t) (C-006)
postfix.if:          66: (C): Unordered declaration in require block (type postfix_master_t before attribute postfix_server_domain) (C-006)
postfix.if:         681: (C): Unordered declaration in require block (attribute postfix_spool_type before attribute postfix_server_tmp_content) (C-006)
networkmanager.if:  127: (C): Unordered declaration in require block (type NetworkManager_t before class dbus) (C-006)
networkmanager.if:  325: (C): Unordered declaration in require block (type NetworkManager_unit_t before class service) (C-006)
networkmanager.if:  344: (C): Unordered declaration in require block (type NetworkManager_unit_t before class service) (C-006)
networkmanager.if:  363: (C): Unordered declaration in require block (type NetworkManager_unit_t before class service) (C-006)
networkmanager.if:  389: (C): Unordered declaration in require block (type NetworkManager_initrc_exec_t before type NetworkManager_etc_t) (C-006)
git.if:              19: (C): Unordered declaration in require block (type gitd_exec_t before type git_user_content_t) (C-006)
bugzilla.if:         59: (C): Unordered declaration in require block (type httpd_bugzilla_script_t before type httpd_bugzilla_content_t) (C-006)
gatekeeper.if:       21: (C): Unordered declaration in require block (type gatekeeper_runtime_t before type gatekeeper_tmp_t) (C-006)
automount.if:       138: (C): Unordered declaration in require block (type automount_lock_t before type automount_tmp_t) (C-006)
uptime.if:           21: (C): Unordered declaration in require block (type uptimed_initrc_exec_t before type uptimed_etc_t) (C-006)
inetd.if:            28: (C): Unordered declaration in require block (type inetd_t before role system_r) (C-006)
sssd.if:            289: (C): Unordered declaration in require block (type sssd_t before class dbus) (C-006)
sssd.if:            336: (C): Unordered declaration in require block (type sssd_public_t before type sssd_initrc_exec_t) (C-006)
rsync.if:           258: (C): Unordered declaration in require block (type rsync_etc_t before type rsync_data_t) (C-006)
kerneloops.if:       34: (C): Unordered declaration in require block (type kerneloops_t before class dbus) (C-006)
kerneloops.if:       56: (C): Unordered declaration in require block (type kerneloops_t before class dbus) (C-006)
kerneloops.if:      103: (C): Unordered declaration in require block (type kerneloops_initrc_exec_t before type kerneloops_tmp_t) (C-006)
callweaver.if:       60: (C): Unordered declaration in require block (type callweaver_var_lib_t before type callweaver_runtime_t) (C-006)
devicekit.if:        54: (C): Unordered declaration in require block (type devicekit_t before class dbus) (C-006)
devicekit.if:        75: (C): Unordered declaration in require block (type devicekit_disk_t before class dbus) (C-006)
devicekit.if:       114: (C): Unordered declaration in require block (type devicekit_power_t before class dbus) (C-006)
devicekit.if:       259: (C): Unordered declaration in require block (type devicekit_var_lib_t before type devicekit_runtime_t) (C-006)
lircd.if:            34: (C): Unordered declaration in require block (type lircd_runtime_t before type lircd_t) (C-006)
lircd.if:            79: (C): Unordered declaration in require block (type lircd_runtime_t before type lircd_initrc_exec_t) (C-006)
rwho.if:            137: (C): Unordered declaration in require block (type rwho_spool_t before type rwho_initrc_exec_t) (C-006)
mta.if:              78: (C): Unordered declaration in require block (attribute mta_user_agent before attribute role user_mail_roles) (C-006)
mta.if:             429: (C): Unordered declaration in require block (type system_mail_t before attribute mta_exec_type) (C-006)
dirmngr.if:          19: (C): Unordered declaration in require block (type dirmngr_exec_t before type dirmngr_tmp_t) (C-006)
dirmngr.if:         115: (C): Unordered declaration in require block (type dirmngr_runtime_t before type dirmngr_conf_t) (C-006)
cvs.if:              60: (C): Unordered declaration in require block (type cvs_initrc_exec_t before type cvs_data_t) (C-006)
colord.if:           34: (C): Unordered declaration in require block (type colord_t before class dbus) (C-006)
avahi.if:            14: (C): Unordered declaration in require block (type avahi_exec_t before type avahi_t) (C-006)
avahi.if:           107: (C): Unordered declaration in require block (type avahi_t before class dbus) (C-006)
avahi.if:           259: (C): Unordered declaration in require block (type avahi_runtime_t before type avahi_initrc_exec_t) (C-006)
rgmanager.if:       100: (C): Unordered declaration in require block (type rgmanager_initrc_exec_t before type rgmanager_tmp_t) (C-006)
condor.if:           59: (C): Unordered declaration in require block (type condor_var_lock_t before type condor_schedd_tmp_t) (C-006)
dkim.if:             14: (C): Unordered declaration in require block (type dkim_milter_data_t before type dkim_milter_t) (C-006)
dkim.if:             39: (C): Unordered declaration in require block (type dkim_milter_private_key_t before type dkim_milter_data_t) (C-006)
dovecot.if:         141: (C): Unordered declaration in require block (type dovecot_var_log_t before type dovecot_spool_t) (C-006)
zarafa.if:          145: (C): Unordered declaration in require block (type zarafa_initrc_exec_t before type zarafa_deliver_tmp_t) (C-006)
keystone.if:         21: (C): Unordered declaration in require block (type keystone_var_lib_t before type keystone_tmp_t) (C-006)
tftp.if:            167: (C): Unordered declaration in require block (type tftpdir_rw_t before type tftpd_runtime_t) (C-006)
openvpn.if:         144: (C): Unordered declaration in require block (type openvpn_var_log_t before type openvpn_runtime_t) (C-006)
aiccu.if:            77: (C): Unordered declaration in require block (type aiccu_initrc_exec_t before type aiccu_etc_t) (C-006)
perdition.if:        21: (C): Unordered declaration in require block (type perdition_initrc_exec_t before type perdition_etc_t) (C-006)
accountsd.if:        54: (C): Unordered declaration in require block (type accountsd_t before class dbus) (C-006)
ssh.if:              36: (C): Unordered declaration in require block (type sshd_key_t before type sshd_tmp_t) (C-006)
ssh.if:             301: (C): Unordered declaration in require block (attribute ssh_server before attribute ssh_agent_type) (C-006)
lldpad.if:           40: (C): Unordered declaration in require block (type lldpad_var_lib_t before type lldpad_runtime_t) (C-006)
xfs.if:              34: (C): Unordered declaration in require block (type xfs_tmp_t before type xfs_t) (C-006)
xfs.if:              98: (C): Unordered declaration in require block (type xfs_runtime_t before type xfs_tmp_t) (C-006)
ftp.if:             160: (C): Unordered declaration in require block (type ftpdctl_t before type ftpd_tmp_t) (C-006)
cobbler.if:         155: (C): Unordered declaration in require block (type cobblerd_t before type cobbler_var_lib_t) (C-006)
smstools.if:         21: (C): Unordered declaration in require block (type smsd_initrc_exec_t before type smsd_conf_t) (C-006)
ricci.if:            92: (C): Unordered declaration in require block (type ricci_modclusterd_t before type ricci_modcluster_runtime_t) (C-006)
ricci.if:           198: (C): Unordered declaration in require block (type ricci_initrc_exec_t before type ricci_tmp_t) (C-006)
pegasus.if:          21: (C): Unordered declaration in require block (type pegasus_initrc_exec_t before type pegasus_tmp_t) (C-006)
sysadm.if:           20: (C): Unordered declaration in require block (type sysadm_t before role sysadm_r) (C-006)
domain.if:         1519: (C): Unordered declaration in require block (attribute set_curr_context before attribute can_change_object_identity) (C-006)
kernel.if:         1284: (C): Unordered declaration in require block (type proc_kcore_t before attribute can_dump_kernel) (C-006)
kernel.if:         1308: (C): Unordered declaration in require block (type proc_kmsg_t before type proc_t) (C-006)
kernel.if:         1330: (C): Unordered declaration in require block (type proc_kmsg_t before type proc_t) (C-006)
kernel.if:         1659: (C): Unordered declaration in require block (type sysctl_t before type proc_t) (C-006)
kernel.if:         1925: (C): Unordered declaration in require block (type sysctl_kernel_t before type sysctl_hotplug_t) (C-006)
kernel.if:         1946: (C): Unordered declaration in require block (type sysctl_kernel_t before type sysctl_hotplug_t) (C-006)
kernel.if:         3526: (C): Unordered declaration in require block (type unlabeled_t before class db_database) (C-006)
selinux.if:         428: (C): Unordered declaration in require block (type security_t before type secure_mode_policyload_t) (C-006)
files.if:            80: (C): Unordered declaration in require block (attribute non_security_file_type before attribute non_auth_file_type) (C-006)
files.if:           100: (C): Unordered declaration in require block (attribute security_file_type before attribute auth_file_type) (C-006)
files.if:           121: (C): Unordered declaration in require block (attribute security_file_type before attribute non_auth_file_type) (C-006)
files.if:          3278: (C): Unordered declaration in require block (type root_t before type etc_runtime_t) (C-006)
files.if:          3304: (C): Unordered declaration in require block (type root_t before type etc_runtime_t) (C-006)
files.if:          5215: (C): Unordered declaration in require block (type usr_t before type src_t) (C-006)
files.if:          5236: (C): Unordered declaration in require block (type usr_t before type src_t) (C-006)
files.if:          5257: (C): Unordered declaration in require block (type usr_t before type src_t) (C-006)
corenetwork.if:     165: (C): Unordered declaration in require block (attribute packet_type before attribute client_packet_type) (C-006)
corenetwork.if:    1370: (C): Unordered declaration in require block (type port_t before attribute defined_port_type) (C-006)
corenetwork.if:    1408: (C): Unordered declaration in require block (type port_t before attribute defined_port_type) (C-006)
corenetwork.if:    1500: (C): Unordered declaration in require block (type unreserved_port_t before attribute defined_port_type) (C-006)
terminal.if:         85: (C): Unordered declaration in require block (attribute ttynode before attribute serial_device) (C-006)
terminal.if:        211: (C): Unordered declaration in require block (attribute ttynode before attribute ptynode) (C-006)
terminal.if:        234: (C): Unordered declaration in require block (attribute ttynode before attribute ptynode) (C-006)
devices.if:        1443: (C): Unordered declaration in require block (type device_t before type acpi_bios_t) (C-006)
devices.if:        1480: (C): Unordered declaration in require block (type device_t before type acpi_bios_t) (C-006)
devices.if:        1517: (C): Unordered declaration in require block (type device_t before type acpi_bios_t) (C-006)
devices.if:        1535: (C): Unordered declaration in require block (type device_t before type agp_device_t) (C-006)
devices.if:        1553: (C): Unordered declaration in require block (type device_t before type agp_device_t) (C-006)
devices.if:        1572: (C): Unordered declaration in require block (type device_t before type autofs_device_t) (C-006)
devices.if:        1609: (C): Unordered declaration in require block (type device_t before type autofs_device_t) (C-006)
devices.if:        1646: (C): Unordered declaration in require block (type device_t before type autofs_device_t) (C-006)
devices.if:        1683: (C): Unordered declaration in require block (type device_t before type cachefiles_device_t) (C-006)
devices.if:        1740: (C): Unordered declaration in require block (type device_t before type cardmgr_dev_t) (C-006)
devices.if:        1760: (C): Unordered declaration in require block (type device_t before type cardmgr_dev_t) (C-006)
devices.if:        1786: (C): Unordered declaration in require block (type device_t before type cardmgr_dev_t) (C-006)
devices.if:        1805: (C): Unordered declaration in require block (type device_t before type cpu_device_t) (C-006)
devices.if:        1824: (C): Unordered declaration in require block (type device_t before type cpu_device_t) (C-006)
devices.if:        1842: (C): Unordered declaration in require block (type device_t before type cpu_device_t) (C-006)
devices.if:        1861: (C): Unordered declaration in require block (type device_t before type cpu_device_t) (C-006)
devices.if:        1879: (C): Unordered declaration in require block (type device_t before type crash_device_t) (C-006)
devices.if:        1897: (C): Unordered declaration in require block (type device_t before type crypt_device_t) (C-006)
devices.if:        2274: (C): Unordered declaration in require block (type framebuf_device_t before type device_t) (C-006)
devices.if:        2769: (C): Unordered declaration in require block (type memory_device_t before attribute memory_raw_read) (C-006)
devices.if:        2799: (C): Unordered declaration in require block (type memory_device_t before attribute memory_raw_read) (C-006)
devices.if:        2847: (C): Unordered declaration in require block (type memory_device_t before attribute memory_raw_write) (C-006)
devices.if:        2877: (C): Unordered declaration in require block (type memory_device_t before attribute memory_raw_write) (C-006)
devices.if:        2952: (C): Unordered declaration in require block (type memory_device_t before attribute memory_raw_write) (C-006)
devices.if:        3442: (C): Unordered declaration in require block (type null_device_t before class service) (C-006)
devices.if:        3480: (C): Unordered declaration in require block (type nvram_device_t before type device_t) (C-006)
devices.if:        3805: (C): Unordered declaration in require block (type device_t before type clock_device_t) (C-006)
devices.if:        3823: (C): Unordered declaration in require block (type device_t before type clock_device_t) (C-006)
devices.if:        4689: (C): Unordered declaration in require block (type usb_device_t before type device_t) (C-006)
devices.if:        4707: (C): Unordered declaration in require block (type usb_device_t before type device_t) (C-006)
devices.if:        4725: (C): Unordered declaration in require block (type usb_device_t before type device_t) (C-006)
devices.if:        4761: (C): Unordered declaration in require block (type usb_device_t before type device_t) (C-006)
Found the following issue counts:
C-006: 547
```