### PR TITLE
Add unit test for declarations in template

### DIFF
--- a/src/parse_functions.c
+++ b/src/parse_functions.c
@@ -92,7 +92,7 @@ enum selint_error insert_declaration(struct policy_node **cur,
 		// In a require block, the objects aren't being declared
 		// Otherwise, we need to insert them into the appropriate map
 
-		char *temp_name = get_name_if_in_template(*cur);
+		const char *temp_name = get_name_if_in_template(*cur);
 
 		if (temp_name) {
 			// We are inside a template, so we need to save declarations in the template map
@@ -152,7 +152,7 @@ enum selint_error insert_aliases(struct policy_node **cur,
 	struct string_list *alias = aliases;
 
 	while (alias) {
-		char *temp_name = get_name_if_in_template(*cur);
+		const char *temp_name = get_name_if_in_template(*cur);
 		if (temp_name) {
 			insert_decl_into_template_map(temp_name, flavor,
 			                              alias->string);

--- a/src/tree.c
+++ b/src/tree.c
@@ -108,7 +108,7 @@ int is_template_call(const struct policy_node *node)
 	return 0;
 }
 
-char *get_name_if_in_template(struct policy_node *cur)
+const char *get_name_if_in_template(const struct policy_node *cur)
 {
 	while (cur->parent) {
 		cur = cur->parent;

--- a/src/tree.h
+++ b/src/tree.h
@@ -216,7 +216,7 @@ enum selint_error insert_policy_node_next(struct policy_node *prev,
 // Returns 1 if the node is a template call, and 0 if not
 int is_template_call(const struct policy_node *node);
 
-char *get_name_if_in_template(struct policy_node *cur);
+const char *get_name_if_in_template(const struct policy_node *cur);
 
 struct string_list *get_names_in_node(const struct policy_node *node);
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -97,6 +97,8 @@ SAMPLE_POLICY_FILES=sample_policy_files/bad_modules.conf \
 			sample_policy_files/basic.te \
 			sample_policy_files/blocks.te \
 			sample_policy_files/bool_declarations.te \
+			sample_policy_files/declaring_template.if \
+			sample_policy_files/declaring_template.te \
 			sample_policy_files/disable_comment.te \
 			sample_policy_files/empty.te \
 			sample_policy_files/modules.conf \

--- a/tests/sample_policy_files/declaring_template.if
+++ b/tests/sample_policy_files/declaring_template.if
@@ -1,0 +1,15 @@
+template(`declaring_template',`
+	type prefix_$1_suffix;
+	type $2_t;
+	role $2_r;
+')
+
+interface(`declaring_helper_if',`
+	# this will not delcare the types in the current module
+	# but there will be a S-004 issued
+	declaring_template(hello, world)
+')
+
+template(`declaring_helper_temp',`
+	declaring_template(good, morning)
+')

--- a/tests/sample_policy_files/declaring_template.te
+++ b/tests/sample_policy_files/declaring_template.te
@@ -1,0 +1,9 @@
+policy_module(delcaring_template, 1.0.0)
+
+declaring_template(foo, bar)
+
+# this will not delcare the types in the current module
+# but there will be a S-004 issued
+declaring_helper_if()
+
+declaring_helper_temp()


### PR DESCRIPTION
I don't know why valgrind is not issuing the ast leak in test_nested_template_declarations currently.