### PR TITLE
Add configure option --enable-werror

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,7 +61,7 @@ jobs:
       run: ./autogen.sh
     - name: configure
       # old flex/bison versions might not generate conversion warning free code
-      run: ./configure CFLAGS="-Werror -Wno-error=conversion -Wno-error=sign-conversion"
+      run: ./configure --enable-werror CFLAGS="-Wno-error=conversion -Wno-error=sign-conversion"
     - name: make
       run: make
     - name: make check
@@ -79,7 +79,7 @@ jobs:
         make VERSION=pipeline-test dist
         tar xvzf selint-pipeline-test.tar.gz
         cd selint-pipeline-test
-        ./configure CFLAGS="-Werror -Wno-error=conversion -Wno-error=sign-conversion"
+        ./configure --enable-werror CFLAGS="-Wno-error=conversion -Wno-error=sign-conversion"
         make
         cd tests/functional
         bats end-to-end.bats

--- a/configure.ac
+++ b/configure.ac
@@ -84,6 +84,10 @@ AX_VALGRIND_CHECK
 AC_CHECK_HEADER([uthash.h], [], [AC_MSG_ERROR([Unable to find uthash header])])
 
 AM_CFLAGS="-Wall -Wextra -Wconversion -Wmissing-format-attribute -Wmissing-noreturn -Wpointer-arith -Wshadow -Wstrict-prototypes -Wundef -Wunused -Wwrite-strings"
+AC_ARG_ENABLE([werror],
+  [AS_HELP_STRING([--enable-werror],
+    [Treat compiler warnings as errors (default: Do not treat as errors)])],
+    [AM_CFLAGS+=" -Werror"])
 AC_SUBST([AM_CFLAGS])
 
 AC_CONFIG_FILES([Makefile src/Makefile tests/Makefile man/Makefile])


### PR DESCRIPTION
Treat compiler warnings as errors by passing -Werror
Avoids passing -Werror in CFLAGS environment variable,
which might break configure test compilations