### PR TITLE
S-009: Check multi class av rules

### DIFF
--- a/tests/functional/end-to-end.bats
+++ b/tests/functional/end-to-end.bats
@@ -131,7 +131,7 @@ test_one_check() {
 
 @test "S-009" {
 	test_one_check_expect "S-009" "s09.pass.te" 0
-	test_one_check_expect "S-009" "s09.warn.te" 4
+	test_one_check_expect "S-009" "s09.warn.te" 6
 }
 
 @test "W-001" {

--- a/tests/functional/policies/check_triggers/s09.pass.te
+++ b/tests/functional/policies/check_triggers/s09.pass.te
@@ -16,9 +16,6 @@ allow source target:chr_file rw_term_perms;
 
 allow source target:process signal_perms;
 
-allow source target:{ file fifo_file } read_file_perms;
-allow source target:{ fifo_file file } read_file_perms;
-
 allow source target:{ tcp_socket udp_socket } create_socket_perms;
 
 allow source target:socket_class_set create_socket_perms;

--- a/tests/functional/policies/check_triggers/s09.warn.te
+++ b/tests/functional/policies/check_triggers/s09.warn.te
@@ -7,3 +7,6 @@ allow source target:file write_lnk_file_perms;
 allow source target:something_socket some_netlink_socket_perms;
 
 allow source target:blk_file rw_term_perms;
+
+allow source target:{ file fifo_file } read_file_perms;
+allow source target:{ fifo_file file } read_file_perms;


### PR DESCRIPTION
Refpolicy finding:
```
postfixpolicyd.te:   40: (S): Permission macro manage_file_perms does not match class file (multi class av rule) (S-009)
```
```
allow postfix_policyd_t postfix_policyd_tmp_t:{ file sock_file } manage_file_perms;
```

Supersedes: #80