### PR TITLE
configure: drop autotool checks for memory allocation functions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -56,8 +56,6 @@ AC_TYPE_UINT32_T
 AC_TYPE_UINT8_T
 
 # Checks for library functions.
-AC_FUNC_MALLOC
-AC_FUNC_REALLOC
 AC_CHECK_FUNCS([memset strdup])
 
 AC_ARG_ENABLE([gcov],


### PR DESCRIPTION
The autotool configure checks do not support cross-compiling.
They might cause failures like:

    checking for GNU libc compatible malloc... no
    checking for GNU libc compatible realloc... no
    ...
    In file included from main.c:27:
    main.c: In function 'main':
    ../config.h:134:16: error: implicit declaration of function 'rpl_malloc'; did you mean 'realloc'? [-Werror=implicit-function-declaration]
      134 | #define malloc rpl_malloc
          |                ^~~~~~~~~~

SELint does not provide a rpl_malloc implementation and does not
intentionally call malloc/realloc with size 0 and expect a non-NULL
pointer.