### PR TITLE
Allow xperm lists as macro argument

### DIFF
--- a/src/parse.y
+++ b/src/parse.y
@@ -390,13 +390,13 @@ xperm_list:
 	|
 	TILDA xperm_list { $$ = sl_from_str("~"); $$->next = $2; }
 	|
-	xperm_item { $$ = calloc(1, sizeof(struct string_list)); $$->string = $1; $$->next = NULL; }
+	xperm_item { $$ = sl_from_str_consume($1); }
 	;
 
 xperm_items:
 	xperm_items xperm_item { $$ = concat_string_lists($1, sl_from_str($2)); free($2); }
 	|
-	xperm_item { $$ = calloc(1, sizeof(struct string_list)); $$->string = $1; $$->next = NULL; }
+	xperm_item { $$ = sl_from_str_consume($1); }
 	;
 
 xperm_item:
@@ -414,7 +414,7 @@ string_list:
 	|
 	TILDA string_list { $$ = sl_from_str("~"); $$->next = $2; }
 	|
-	sl_item { $$ = calloc(1, sizeof(struct string_list)); $$->string = $1; $$->next = NULL; }
+	sl_item { $$ = sl_from_str_consume($1); }
 	|
 	STAR { $$ = sl_from_str("*"); }
 	;
@@ -422,11 +422,11 @@ string_list:
 strings:
 	strings sl_item { $$ = concat_string_lists($1, sl_from_str($2)); free($2); }
 	|
-	sl_item { $$ = calloc(1, sizeof(struct string_list)); $$->string = $1; $$->next = NULL; }
+	sl_item { $$ = sl_from_str_consume($1); }
 	;
 
 sl_item:
-	STRING { $$ = strdup($1); free($1);}
+	STRING
 	|
 	DASH STRING { $$ = malloc(sizeof(char) * (strlen($2) + 2));
 			$$[0] = '-';
@@ -434,13 +434,13 @@ sl_item:
 			strcat($$, $2);
 			free($2);}
 	|
-	QUOTED_STRING { $$ = strdup($1); free($1);}
+	QUOTED_STRING
 	;
 
 comma_string_list:
 	comma_string_list COMMA STRING { $$ = concat_string_lists($1, sl_from_str($3)); free($3); }
 	|
-	STRING { $$ = sl_from_str($1); free($1); }
+	STRING { $$ = sl_from_str_consume($1); }
 	;
 
 role_allow:

--- a/src/parse.y
+++ b/src/parse.y
@@ -676,7 +676,9 @@ m4_argument:
 	;
 
 arg:
-	string_list
+	xperm_list
+	|
+	QUOTED_STRING { $$ = sl_from_str_consume($1); }
 	|
 	BACKTICK strings SINGLE_QUOTE { $$ = $2; }
 	|

--- a/src/string_list.c
+++ b/src/string_list.c
@@ -78,6 +78,16 @@ struct string_list *sl_from_strn(const char *string, size_t len)
 	return ret;
 }
 
+struct string_list *sl_from_str_consume(char *string)
+{
+	struct string_list *ret = malloc(sizeof(struct string_list));
+	ret->string = string;
+	ret->next = NULL;
+	ret->has_incorrect_space = 0;
+
+	return ret;
+}
+
 struct string_list *sl_from_strs(int count, ...)
 {
 	struct string_list *ret = NULL;

--- a/src/string_list.h
+++ b/src/string_list.h
@@ -34,6 +34,10 @@ struct string_list *copy_string_list(const struct string_list *sl);
 struct string_list *sl_from_str(const char *string);
 struct string_list *sl_from_strn(const char *string, size_t len);
 
+// Return a string list with the given string as single item
+// Takes ownership of the given string
+struct string_list *sl_from_str_consume(char *string);
+
 // Return a string list with copies of the given strings
 struct string_list *sl_from_strs(int count, ...);
 

--- a/tests/sample_policy_files/uncommon.te
+++ b/tests/sample_policy_files/uncommon.te
@@ -104,3 +104,6 @@ type type_t alias { alias1 alias2 alias3 }, attribute1;
 type type_t alias { alias1 alias2 alias3 }, attribute1, attribute2, attribute3;
 
 refpolicywarn(`$0($*) has been deprecated, please use foo(); instead.')
+
+xperm_macro(foo_t, bar_t, 0x1234)
+xperm_macro(foo_t, bar_t, { 0x5000 - 0x50ff 1234 })


### PR DESCRIPTION
```
xperm_macro(foo_t, bar_t, 0x1234)
xperm_macro(foo_t, bar_t, { 0x5000 - 0x50ff 1234 })
```