### PR TITLE
Parse m4 define arguments as lax arbitrary string

### DIFF
--- a/src/parse.y
+++ b/src/parse.y
@@ -677,6 +677,8 @@ m4_string_elem:
 	COLON
 	|
 	SEMICOLON
+	|
+	DASH
 	;
 
 condition:
@@ -839,7 +841,21 @@ fs_use:
 	;
 
 define:
-	DEFINE OPEN_PAREN m4_args CLOSE_PAREN
+	DEFINE OPEN_PAREN define_name COMMA define_expansion CLOSE_PAREN
+	;
+
+define_name:
+	BACKTICK STRING SINGLE_QUOTE { free($2); }
+	|
+	STRING { free($1); }
+	;
+
+define_expansion:
+	%empty
+	|
+	BACKTICK arbitrary_m4_string SINGLE_QUOTE
+	|
+	STRING { free($1); }
 	;
 
 maybe_string_comma:

--- a/tests/sample_policy_files/uncommon.te
+++ b/tests/sample_policy_files/uncommon.te
@@ -119,3 +119,5 @@ ifdef(`foo',`
 	# comment
 	bare_word
 ')
+
+define(`not_foo',`-foo_t')


### PR DESCRIPTION
Allows to parse
```
define(`not_foo',`-foo_t')
```

Note: with this patch the content of `defines` are not inserted into the syntax tree, e.g. with
```
define(`foo`, `type bar_t`)
```
`bar_t` is not added into the types-map.