### PR TITLE
RFC: Add check for wide directory path file contexts

### DIFF
--- a/README
+++ b/README
@@ -157,6 +157,7 @@ CHECK IDS
 	C-005: Permissions in av rule or class declaration not ordered
 	C-006: Declarations in require block not ordered
 	C-007: Redudant type specification instead of self keyword
+	C-008: Use of wide directory path file context
 
 	S-001: Require block used instead of interface call
 	S-002: File context file labels with type not declared in module

--- a/check_examples.txt
+++ b/check_examples.txt
@@ -28,6 +28,10 @@ C-006:
 		class foobar;
 	')
 
+C-007:
+
+	allow myapp_t myapp_t:process signal;
+
 Style:
 
 S-001:
@@ -178,3 +182,7 @@ E-009:
 	optional_policy(`
 		#do_something(type_t)
 	')
+
+E-010:
+
+	bare_m4_macro

--- a/check_examples.txt
+++ b/check_examples.txt
@@ -32,6 +32,10 @@ C-007:
 
 	allow myapp_t myapp_t:process signal;
 
+C-008:
+
+	/var/lib/myapp(/.*)?  ...
+
 Style:
 
 S-001:

--- a/src/check_hooks.h
+++ b/src/check_hooks.h
@@ -27,6 +27,7 @@ enum convention_ids {
 	C_ID_UNORDERED_PERM = 5,
 	C_ID_UNORDERED_REQ  = 6,
 	C_ID_SELF           = 7,
+	C_ID_WIDE_DIR_FC    = 8,
 	C_END
 };
 

--- a/src/fc_checks.c
+++ b/src/fc_checks.c
@@ -34,6 +34,23 @@
 		return NULL; \
 	} \
 
+struct check_result *check_wide_dir_path_fcontext(__attribute__((unused)) const struct check_data
+                                                  *data,
+                                                  const struct policy_node
+                                                  *node)
+{
+	SETUP_FOR_FC_CHECK(node)
+
+	if (ends_with(entry->path, strlen(entry->path), "(/.*)?", strlen("(/.*)?"))) {
+		return make_check_result('C',
+					 C_ID_WIDE_DIR_FC,
+					 "File context path %s ends on '(/.*)?', which might match unwanted non-directory entries.",
+					 entry->path);
+	}
+
+	return NULL;
+}
+
 struct check_result *check_file_context_types_in_mod(const struct check_data
                                                      *data,
                                                      const struct policy_node

--- a/src/fc_checks.h
+++ b/src/fc_checks.h
@@ -20,6 +20,17 @@
 #include "check_hooks.h"
 
 /*********************************************
+ * Check for wide dir path file contexts.
+ * Called on NODE_FC_ENTRY nodes.
+ * node - the node to check
+ * returns NULL if passed or check_result for issue C-008
+ *********************************************/
+struct check_result *check_wide_dir_path_fcontext(const struct check_data
+                                                  *data,
+                                                  const struct policy_node
+                                                  *node);
+
+/*********************************************
 * Check for issues with file context labels type field.
 * Called on NODE_FC_ENTRY nodes.
 * node - the node to check

--- a/src/runner.c
+++ b/src/runner.c
@@ -146,6 +146,10 @@ struct checks *register_checks(char level,
 			add_check(NODE_XAV_RULE, ck, "C-007",
 			          check_no_self);
 		}
+		if (CHECK_ENABLED("C-008")) {
+			add_check(NODE_FC_ENTRY, ck, "C-008",
+				  check_wide_dir_path_fcontext);
+		}
 		// FALLTHRU
 	case 'S':
 		if (CHECK_ENABLED("S-001")) {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -131,6 +131,7 @@ FUNCTIONAL_TEST_FILES=functional/end-to-end.bats \
 			functional/policies/check_triggers/c06.warn.if \
 			functional/policies/check_triggers/c07.te \
 			functional/policies/check_triggers/c07.if \
+			functional/policies/check_triggers/c08.fc \
 			functional/policies/check_triggers/e02.fc \
 			functional/policies/check_triggers/e03e04e05.fc \
 			functional/policies/check_triggers/e06.te \

--- a/tests/functional/end-to-end.bats
+++ b/tests/functional/end-to-end.bats
@@ -151,6 +151,10 @@ test_parse_error_impl() {
 	test_one_check "C-007" "c07.if"
 }
 
+@test "C-008" {
+	test_one_check "C-008" "c08.fc"
+}
+
 @test "S-001" {
 	test_one_check "S-001" "s01.te"
 }

--- a/tests/functional/policies/check_triggers/c08.fc
+++ b/tests/functional/policies/check_triggers/c08.fc
@@ -1,0 +1,1 @@
+/var/lib/myapp(/.*)?		--	gen_context(system_u:object_r:myapp_lib_t,s0)


### PR DESCRIPTION
Using a file context `/var/lib/myapp(/.*)? gen_context(...` is common,
but it matches non-directory entries /var/lib/myapp.

One might want to specify two file contexts:
```
    /var/lib/myapp     -d gen_context(...
    /var/lib/myapp/.*     gen_context(...
```

Due do this type of file contexts being a common practice, it is debatable if such check should be added, and if so if it should be enabled by default.