### PR TITLE
Fix 32-bit sign comparisons

### DIFF
--- a/src/parse.y
+++ b/src/parse.y
@@ -1109,9 +1109,9 @@ static void yyerror(const YYLTYPE *locp, __attribute__((unused)) yyscan_t scanne
 		}
 		for (const char *c = current_line; *c != '\0'; ++c) {
 			if (*c == '\t') {
-				if (c - current_line < current_first_column) {
+				if ((size_t)(c - current_line) < current_first_column) {
 					tabs_before_hinter++;
-				} else if (c - current_line < current_last_column) {
+				} else if ((size_t)(c - current_line) < current_last_column) {
 					tabs_inside_hinter++;
 				}
 				printf("    ");


### PR DESCRIPTION
```
parse.y: In function 'yyerror':
parse.y:1111:26: error: comparison of integer expressions of different signedness: 'int' and 'unsigned int' [-Werror=sign-compare]
 1111 |     if (c - current_line < current_first_column) {
      |                          ^
parse.y:1113:33: error: comparison of integer expressions of different signedness: 'int' and 'unsigned int' [-Werror=sign-compare]
 1113 |     } else if (c - current_line < current_last_column) {
      |                                 ^
```