### PR TITLE
Allow define() without expansion

### DIFF
--- a/src/parse.y
+++ b/src/parse.y
@@ -842,13 +842,19 @@ fs_use:
 
 define:
 	DEFINE OPEN_PAREN { begin_define(&cur, @$.first_line); }
-	define_name COMMA define_expansion CLOSE_PAREN { end_define(&cur); }
+	define_name define_content CLOSE_PAREN { end_define(&cur); }
 	;
 
 define_name:
 	BACKTICK STRING SINGLE_QUOTE { free($2); }
 	|
 	STRING { free($1); }
+	;
+
+define_content:
+	%empty
+	|
+	COMMA define_expansion
 	;
 
 define_expansion:

--- a/tests/sample_policy_files/uncommon.te
+++ b/tests/sample_policy_files/uncommon.te
@@ -121,3 +121,5 @@ ifdef(`foo',`
 ')
 
 define(`not_foo',`-foo_t')
+
+define(`foobar')


### PR DESCRIPTION
This allows parsing statements such as "define(`something')", which are
perfectly valid.