### PR TITLE
Remove Codecov from CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,12 +90,6 @@ jobs:
         make
         cd tests/functional
         BATS_TIME_EXPENSIVE=1 bats end-to-end.bats
-    - name: Codecov upload
-      run: |
-        if [[ ${{ matrix.cc }} == 'gcc' ]]
-        then
-          bash <(curl -s https://codecov.io/bash)
-        fi
     - name: checkout refpolicy
       uses: actions/checkout@v2
       with:


### PR DESCRIPTION
A recent compromise of codecov highlights the issues with curling and
executing a bash script as part of your CI.

https://about.codecov.io/security-update/

While it doesn't sound to me like we have anything to be specifically concerned about
from this particular breach, it seems prudent to me to treat codecov as
a potential attack vector and remove it from our CI.

It has been my experience that the results from codecov's scans are of
questionable value anyways, and so I don't think we're losing a lot by
not including it.