### PR TITLE
Clang 12 and CI update

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,21 +33,21 @@ jobs:
         if [[ ${{ matrix.cc }} == 'clang' ]]
         then
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key 2>/dev/null | sudo apt-key add -
-          sudo add-apt-repository 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main' -y
+          sudo add-apt-repository 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-12 main' -y
           sudo apt-get update -q
-          sudo apt-get install -y clang-10
+          sudo apt-get install -y clang-12
         fi
     - name: install dependencies
       run: |
         sudo apt-get update -q
-        sudo apt-get install -y uthash-dev libconfuse-dev autoconf-archive bison byacc flex valgrind help2man
+        sudo apt-get install -y uthash-dev libconfuse-dev autoconf-archive bison byacc flex valgrind help2man bats
     # Install libcheck from source.  Ubuntu is on version 0.10.0, and ck_assert_ptr_null and
     # ck_assert_ptr_nonnull were added in 0.11.0
     - name: checkout check
       uses: actions/checkout@v2
       with:
         repository: libcheck/check
-        ref: 0.13.0
+        ref: 0.15.2
         path: check
     - name: install check
       run : |
@@ -59,30 +59,15 @@ jobs:
         sudo ldconfig
         cd ..
         rm -rf check/
-    # Install bats.  Ubuntu is on 0.4.0 and the latest is 1.1.0.  This is to work around
-    # a bug with running a program multiple times in the same test
-    - name: checkout bats
-      uses: actions/checkout@v2
-      with:
-        repository: bats-core/bats-core
-        ref: v1.2.1
-        path: bats-core
-    - name: install bats
-      run : |
-        cd bats-core/
-        sudo ./install.sh /usr/local
-        cd ..
-        rm -rf bats-core/
     - name: autogen
       run: ./autogen.sh
     - name: configure
-      # old flex/bison versions might not generate conversion warning free code
       run: |
         if [[ ${{ matrix.cc }} == 'gcc' ]]
         then
-          ./configure --enable-werror CFLAGS="-Wno-error=conversion -Wno-error=sign-conversion --coverage"
+          ./configure --enable-werror CFLAGS=--coverage
         else
-          ./configure --enable-werror CFLAGS="-Wno-error=conversion -Wno-error=sign-conversion"
+          ./configure --enable-werror
         fi
     - name: make
       run: make
@@ -91,7 +76,7 @@ jobs:
     - name: make check-valgrind
       run: make check-valgrind
     - name: make distcheck
-      run: make distcheck DISTCHECK_CONFIGURE_FLAGS=--enable-werror CFLAGS="-Wno-error=conversion -Wno-error=sign-conversion"
+      run: make distcheck DISTCHECK_CONFIGURE_FLAGS=--enable-werror
     - name: functional tests
       run : |
         cd ./tests/functional
@@ -101,7 +86,7 @@ jobs:
         make VERSION=pipeline-test dist
         tar xvzf selint-pipeline-test.tar.gz
         cd selint-pipeline-test
-        ./configure --enable-werror CFLAGS="-Wno-error=conversion -Wno-error=sign-conversion"
+        ./configure --enable-werror
         make
         cd tests/functional
         BATS_TIME_EXPENSIVE=1 bats end-to-end.bats

--- a/src/maps.c
+++ b/src/maps.c
@@ -35,6 +35,9 @@ static struct template_hash_elem *template_map = NULL;
 
 #if defined(__clang__) && defined(__clang_major__) && (__clang_major__ >= 4)
 __attribute__((no_sanitize("unsigned-integer-overflow")))
+#if (__clang_major__ >= 12)
+__attribute__((no_sanitize("unsigned-shift-base")))
+#endif
 #endif
 static struct hash_elem *look_up_hash_elem(const char *name, enum decl_flavor flavor)
 {
@@ -79,6 +82,9 @@ static struct hash_elem *look_up_hash_elem(const char *name, enum decl_flavor fl
 
 #if defined(__clang__) && defined(__clang_major__) && (__clang_major__ >= 4)
 __attribute__((no_sanitize("unsigned-integer-overflow")))
+#if (__clang_major__ >= 12)
+__attribute__((no_sanitize("unsigned-shift-base")))
+#endif
 #endif
 void insert_into_decl_map(const char *name, const char *module_name,
                           enum decl_flavor flavor)
@@ -148,6 +154,9 @@ const char *look_up_in_decl_map(const char *name, enum decl_flavor flavor)
 
 #if defined(__clang__) && defined(__clang_major__) && (__clang_major__ >= 4)
 __attribute__((no_sanitize("unsigned-integer-overflow")))
+#if (__clang_major__ >= 12)
+__attribute__((no_sanitize("unsigned-shift-base")))
+#endif
 #endif
 void insert_into_mods_map(const char *mod_name, const char *status)
 {
@@ -167,6 +176,9 @@ void insert_into_mods_map(const char *mod_name, const char *status)
 
 #if defined(__clang__) && defined(__clang_major__) && (__clang_major__ >= 4)
 __attribute__((no_sanitize("unsigned-integer-overflow")))
+#if (__clang_major__ >= 12)
+__attribute__((no_sanitize("unsigned-shift-base")))
+#endif
 #endif
 const char *look_up_in_mods_map(const char *mod_name)
 {
@@ -184,6 +196,9 @@ const char *look_up_in_mods_map(const char *mod_name)
 
 #if defined(__clang__) && defined(__clang_major__) && (__clang_major__ >= 4)
 __attribute__((no_sanitize("unsigned-integer-overflow")))
+#if (__clang_major__ >= 12)
+__attribute__((no_sanitize("unsigned-shift-base")))
+#endif
 #endif
 void insert_into_mod_layers_map(const char *mod_name, const char *layer)
 {
@@ -203,6 +218,9 @@ void insert_into_mod_layers_map(const char *mod_name, const char *layer)
 
 #if defined(__clang__) && defined(__clang_major__) && (__clang_major__ >= 4)
 __attribute__((no_sanitize("unsigned-integer-overflow")))
+#if (__clang_major__ >= 12)
+__attribute__((no_sanitize("unsigned-shift-base")))
+#endif
 #endif
 const char *look_up_in_mod_layers_map(const char *mod_name)
 {
@@ -219,6 +237,9 @@ const char *look_up_in_mod_layers_map(const char *mod_name)
 
 #if defined(__clang__) && defined(__clang_major__) && (__clang_major__ >= 4)
 __attribute__((no_sanitize("unsigned-integer-overflow")))
+#if (__clang_major__ >= 12)
+__attribute__((no_sanitize("unsigned-shift-base")))
+#endif
 #endif
 void insert_into_ifs_map(const char *if_name, const char *mod_name)
 {
@@ -238,6 +259,9 @@ void insert_into_ifs_map(const char *if_name, const char *mod_name)
 
 #if defined(__clang__) && defined(__clang_major__) && (__clang_major__ >= 4)
 __attribute__((no_sanitize("unsigned-integer-overflow")))
+#if (__clang_major__ >= 12)
+__attribute__((no_sanitize("unsigned-shift-base")))
+#endif
 #endif
 const char *look_up_in_ifs_map(const char *if_name)
 {
@@ -279,6 +303,9 @@ unsigned int decl_map_count(enum decl_flavor flavor)
 
 #if defined(__clang__) && defined(__clang_major__) && (__clang_major__ >= 4)
 __attribute__((no_sanitize("unsigned-integer-overflow")))
+#if (__clang_major__ >= 12)
+__attribute__((no_sanitize("unsigned-shift-base")))
+#endif
 #endif
 void mark_transform_if(const char *if_name)
 {
@@ -299,6 +326,9 @@ void mark_transform_if(const char *if_name)
 
 #if defined(__clang__) && defined(__clang_major__) && (__clang_major__ >= 4)
 __attribute__((no_sanitize("unsigned-integer-overflow")))
+#if (__clang_major__ >= 12)
+__attribute__((no_sanitize("unsigned-shift-base")))
+#endif
 #endif
 int is_transform_if(const char *if_name)
 {
@@ -313,6 +343,9 @@ int is_transform_if(const char *if_name)
 
 #if defined(__clang__) && defined(__clang_major__) && (__clang_major__ >= 4)
 __attribute__((no_sanitize("unsigned-integer-overflow")))
+#if (__clang_major__ >= 12)
+__attribute__((no_sanitize("unsigned-shift-base")))
+#endif
 #endif
 void mark_filetrans_if(const char *if_name)
 {
@@ -333,6 +366,9 @@ void mark_filetrans_if(const char *if_name)
 
 #if defined(__clang__) && defined(__clang_major__) && (__clang_major__ >= 4)
 __attribute__((no_sanitize("unsigned-integer-overflow")))
+#if (__clang_major__ >= 12)
+__attribute__((no_sanitize("unsigned-shift-base")))
+#endif
 #endif
 int is_filetrans_if(const char *if_name)
 {
@@ -347,6 +383,9 @@ int is_filetrans_if(const char *if_name)
 
 #if defined(__clang__) && defined(__clang_major__) && (__clang_major__ >= 4)
 __attribute__((no_sanitize("unsigned-integer-overflow")))
+#if (__clang_major__ >= 12)
+__attribute__((no_sanitize("unsigned-shift-base")))
+#endif
 #endif
 void mark_role_if(const char *if_name)
 {
@@ -367,6 +406,9 @@ void mark_role_if(const char *if_name)
 
 #if defined(__clang__) && defined(__clang_major__) && (__clang_major__ >= 4)
 __attribute__((no_sanitize("unsigned-integer-overflow")))
+#if (__clang_major__ >= 12)
+__attribute__((no_sanitize("unsigned-shift-base")))
+#endif
 #endif
 int is_role_if(const char *if_name)
 {
@@ -413,6 +455,9 @@ static void insert_noop(__attribute__((unused)) struct template_hash_elem *templ
 
 #if defined(__clang__) && defined(__clang_major__) && (__clang_major__ >= 4)
 __attribute__((no_sanitize("unsigned-integer-overflow")))
+#if (__clang_major__ >= 12)
+__attribute__((no_sanitize("unsigned-shift-base")))
+#endif
 #endif
 static void insert_into_template_map(const char *name, void *new_node,
                               void (*insertion_func)(struct template_hash_elem
@@ -473,6 +518,9 @@ void insert_call_into_template_map(const char *name, struct if_call_data *call)
 
 #if defined(__clang__) && defined(__clang_major__) && (__clang_major__ >= 4)
 __attribute__((no_sanitize("unsigned-integer-overflow")))
+#if (__clang_major__ >= 12)
+__attribute__((no_sanitize("unsigned-shift-base")))
+#endif
 #endif
 const struct template_hash_elem *look_up_in_template_map(const char *name)
 {
@@ -508,6 +556,9 @@ const struct if_call_list *look_up_call_in_template_map(const char *name)
 
 #if defined(__clang__) && defined(__clang_major__) && (__clang_major__ >= 4)
 __attribute__((no_sanitize("unsigned-integer-overflow")))
+#if (__clang_major__ >= 12)
+__attribute__((no_sanitize("unsigned-shift-base")))
+#endif
 #endif
 void insert_into_permmacros_map(const char *name, struct string_list *permissions)
 {
@@ -527,6 +578,9 @@ void insert_into_permmacros_map(const char *name, struct string_list *permission
 
 #if defined(__clang__) && defined(__clang_major__) && (__clang_major__ >= 4)
 __attribute__((no_sanitize("unsigned-integer-overflow")))
+#if (__clang_major__ >= 12)
+__attribute__((no_sanitize("unsigned-shift-base")))
+#endif
 #endif
 const struct string_list *look_up_in_permmacros_map(const char *name)
 {


### PR DESCRIPTION
* Modernize CI to focal (20.04)
  - use clang-12
  - use packaged bats, it is recent enough
  - update check version to 0.15.2
  - drop no more needed compiler warning overrides for code generated by
    old flex/bison versions

* Ignore Clang 12 UBSAN reports in hash functions
  Clang 12 complains about unsigned-shift-base in `HASH_FIND()`.


