### PR TITLE
RFC:  Add extra check for unused interfaces

### DIFF
--- a/README
+++ b/README
@@ -117,6 +117,8 @@ SEVERITY LEVELS
 	significance of the issue.  Available levels are listed below in increasing
 	order of significance.
 
+	X (extra) - Miscellaneous checks, mainly for policy introspection.
+	These must be explicitly enabled with their individual identifier.
 	C (convention) - A violation of common style conventions
 	S (style) - Stylistic "code smell" that may be associated with unintended
 	behavior
@@ -151,6 +153,8 @@ OUTPUT
 CHECK IDS
 
 	The following checks may be performed:
+
+	X-001: Unused interface or template declaration
 
 	C-001: Violation of refpolicy te file ordering conventions
 	C-004: Interface does not have documentation comment

--- a/src/check_hooks.h
+++ b/src/check_hooks.h
@@ -21,6 +21,11 @@
 #include "selint_error.h"
 #include "selint_config.h"
 
+enum extra_ids {
+	X_ID_UNUSED_IF = 1,
+	X_END
+};
+
 enum convention_ids {
 	C_ID_TE_ORDER       = 1,
 	C_ID_IF_COMMENT     = 4,

--- a/src/if_checks.c
+++ b/src/if_checks.c
@@ -25,6 +25,25 @@
 
 #define NOT_REQ_MESSAGE "%s %s is used in interface but not required"
 
+struct check_result *check_unused_interface(__attribute__((unused)) const struct
+                                            check_data *data,
+                                            const struct
+                                            policy_node *node)
+{
+	if (node->flavor != NODE_INTERFACE_DEF && node->flavor != NODE_TEMP_DEF) {
+		return alloc_internal_error(
+			"Unused interface check called on non interface definition entry");
+	}
+
+	const char *if_name = node->data.str;
+
+	if (is_used_if(if_name)) {
+		return NULL;
+	}
+
+	return make_check_result('X', X_ID_UNUSED_IF, "Interface %s is unused", if_name);
+}
+
 struct check_result *check_interface_definitions_have_comment(__attribute__((unused)) const struct
                                                               check_data *data,
                                                               const struct

--- a/src/if_checks.h
+++ b/src/if_checks.h
@@ -20,6 +20,19 @@
 #include "check_hooks.h"
 
 /*********************************************
+* Check for unused interfaces and templates
+* Called on NODE_INTERFACE_DEF and NODE_TEMP_DEF nodes.
+* data - metadata about the file
+* node - the node to check
+* returns NULL if passed or check_result for issue X-001
+*********************************************/
+struct check_result *check_unused_interface(const struct
+                                            check_data *data,
+                                            const struct
+                                            policy_node
+                                            *node);
+
+/*********************************************
 * Check to make sure all interfaces and templates have a comment above them
 * Called on NODE_INTERFACE_DEF and NODE_TEMP_DEF nodes.
 * data - metadata about the file

--- a/src/maps.h
+++ b/src/maps.h
@@ -26,19 +26,25 @@ struct hash_elem {
 	char *key;
 	char *val;
 	UT_hash_handle hh_type, hh_role, hh_user, hh_attr_type, hh_attr_role, hh_bool,
-	               hh_class, hh_perm, hh_mods, hh_ifs, hh_mod_layers;
-};
-
-struct bool_hash_elem {
-	char *key;
-	int val;
-	UT_hash_handle hh_transform, hh_filetrans, hh_role_if, hh_used_if;
+	               hh_class, hh_perm, hh_mods, hh_mod_layers;
 };
 
 struct sl_hash_elem {
 	char *key;
 	struct string_list *val;
 	UT_hash_handle hh_permmacros;
+};
+
+#define TRANSFORM_IF (1u << 0)
+#define FILETRANS_IF (1u << 1)
+#define ROLE_IF      (1u << 2)
+#define USED_IF      (1u << 3)
+
+struct if_hash_elem {
+	char *name;
+	char *module;
+	uint8_t flags;
+	UT_hash_handle hh_interfaces;
 };
 
 struct template_hash_elem {

--- a/src/maps.h
+++ b/src/maps.h
@@ -32,7 +32,7 @@ struct hash_elem {
 struct bool_hash_elem {
 	char *key;
 	int val;
-	UT_hash_handle hh_transform, hh_filetrans, hh_role_if;
+	UT_hash_handle hh_transform, hh_filetrans, hh_role_if, hh_used_if;
 };
 
 struct sl_hash_elem {
@@ -76,6 +76,10 @@ int is_filetrans_if(const char *if_name);
 void mark_role_if(const char *if_name);
 
 int is_role_if(const char *if_name);
+
+void mark_used_if(const char *if_name);
+
+int is_used_if(const char *if_name);
 
 // Just generate a template entry in the map, but don't save any calls
 // or decls to it.  This is helpful to know what is a template for certain

--- a/src/parse_functions.c
+++ b/src/parse_functions.c
@@ -456,6 +456,8 @@ enum selint_error insert_interface_call(struct policy_node **cur, const char *if
 		mark_filetrans_if((*cur)->parent->data.str);
 	}
 
+	mark_used_if(if_name);
+
 	union node_data nd;
 	nd.ic_data = if_data;
 	enum selint_error ret = insert_policy_node_next(*cur,

--- a/src/runner.c
+++ b/src/runner.c
@@ -61,7 +61,7 @@ int is_check_enabled(const char *check_name,
                      int only_enabled)
 {
 
-	int is_enabled = 1;     // default to enabled
+	int is_enabled = check_name[0] == 'X' ? 0 : 1;     // default to enabled, except for extra checks
 
 	if (only_enabled) {
 		// if only_enabled is true, we only want to enable checks that are
@@ -101,6 +101,13 @@ struct checks *register_checks(char level,
 	struct checks *ck = malloc(sizeof(struct checks));
 
 	memset(ck, 0, sizeof(struct checks));
+
+	if (CHECK_ENABLED("X-001")) {
+		add_check(NODE_INTERFACE_DEF, ck, "X-001",
+			  check_unused_interface);
+		add_check(NODE_TEMP_DEF, ck, "X-001",
+			  check_unused_interface);
+	}
 
 	switch (level) {
 	case 'C':

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -181,6 +181,8 @@ FUNCTIONAL_TEST_FILES=functional/end-to-end.bats \
 			functional/policies/check_triggers/w10.warn.te \
 			functional/policies/check_triggers/w11.te \
 			functional/policies/check_triggers/w11.if \
+			functional/policies/check_triggers/x01.if \
+			functional/policies/check_triggers/x01.te \
 			functional/policies/check_triggers/C-001/interleaved.expect.ref \
 			functional/policies/check_triggers/C-001/interleaved.expect.lax \
 			functional/policies/check_triggers/C-001/interleaved.te \

--- a/tests/check_check_hooks.c
+++ b/tests/check_check_hooks.c
@@ -170,7 +170,7 @@ START_TEST (test_is_valid_check) {
 	ck_assert_int_eq(1, is_valid_check("S-001"));
 	ck_assert_int_eq(1, is_valid_check("E-001"));
 	ck_assert_int_eq(1, is_valid_check("F-001"));
-	ck_assert_int_eq(0, is_valid_check("X-001"));
+	ck_assert_int_eq(0, is_valid_check("Y-001"));
 	ck_assert_int_eq(0, is_valid_check("C-101"));
 }
 END_TEST

--- a/tests/functional/end-to-end.bats
+++ b/tests/functional/end-to-end.bats
@@ -122,6 +122,10 @@ test_parse_error_impl() {
 	fi
 }
 
+@test "X-001" {
+	test_one_check "X-001" "x01.*"
+}
+
 @test "C-001" {
 	test_ordering "simple"
 	test_ordering "interleaved"

--- a/tests/functional/policies/check_triggers/x01.if
+++ b/tests/functional/policies/check_triggers/x01.if
@@ -1,0 +1,5 @@
+interface(`used_if',`
+')
+
+interface(`unused_if',`
+')

--- a/tests/functional/policies/check_triggers/x01.te
+++ b/tests/functional/policies/check_triggers/x01.te
@@ -1,0 +1,5 @@
+policy_module(x01, 0.1)
+
+type foo_t;
+
+used_if(foo_t)


### PR DESCRIPTION
Disabled by default, needs explicit activation.

Add a new severity level 'X' for this introspection check.

