### PR TITLE
Allow a disable comment after interface declaration

### DIFF
--- a/src/parse.y
+++ b/src/parse.y
@@ -930,7 +930,11 @@ if_line:
 interface_def:
 	start_interface lines end_interface
 	|
+	start_interface SELINT_COMMAND lines end_interface { save_command(cur, $2); free($2); }
+	|
 	start_interface end_interface
+	|
+	start_interface SELINT_COMMAND end_interface  { save_command(cur, $2); free($2); }
 	;
 
 start_interface:

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -102,6 +102,7 @@ SAMPLE_POLICY_FILES=sample_policy_files/access_vectors \
 			sample_policy_files/bool_declarations.te \
 			sample_policy_files/declaring_template.if \
 			sample_policy_files/declaring_template.te \
+			sample_policy_files/disable_comment.if \
 			sample_policy_files/disable_comment.te \
 			sample_policy_files/empty.te \
 			sample_policy_files/extended_perms.te \

--- a/tests/check_parsing.c
+++ b/tests/check_parsing.c
@@ -29,7 +29,8 @@
 #define EMPTY_TE_FILENAME POLICIES_DIR "empty.te"
 #define SYNTAX_ERROR_FILENAME POLICIES_DIR "syntax_error.te"
 #define BAD_RA_FILENAME POLICIES_DIR "bad_role_allow.te"
-#define DISABLE_COMMENT_FILENAME POLICIES_DIR "disable_comment.te"
+#define DISABLE_COMMENT_TE_FILENAME POLICIES_DIR "disable_comment.te"
+#define DISABLE_COMMENT_IF_FILENAME POLICIES_DIR "disable_comment.if"
 #define BOOL_DECLARATION_FILENAME POLICIES_DIR "bool_declarations.te"
 #define EXTENDED_TE_FILENAME POLICIES_DIR "extended_perms.te"
 #define IFDEF_BLOCK_FILENAME POLICIES_DIR "ifdef_block.te"
@@ -280,13 +281,13 @@ START_TEST (test_parse_bad_role_allow) {
 }
 END_TEST
 
-START_TEST (test_disable_comment) {
+START_TEST (test_disable_comment_te) {
 
 	set_current_module_name("disable_comment");
 
-	FILE *f = fopen(DISABLE_COMMENT_FILENAME, "r");
+	FILE *f = fopen(DISABLE_COMMENT_TE_FILENAME, "r");
 	ck_assert_ptr_nonnull(f);
-	struct policy_node *ast = yyparse_wrapper(f, DISABLE_COMMENT_FILENAME, NODE_TE_FILE);
+	struct policy_node *ast = yyparse_wrapper(f, DISABLE_COMMENT_TE_FILENAME, NODE_TE_FILE);
 	ck_assert_ptr_nonnull(ast);
 
 	ck_assert_ptr_nonnull(ast);
@@ -298,6 +299,29 @@ START_TEST (test_disable_comment) {
 	ck_assert_ptr_nonnull(ast->next->next->next);
 	ck_assert_int_eq(NODE_AV_RULE, ast->next->next->next->flavor);
 	ck_assert_str_eq("W-001", ast->next->next->next->exceptions);
+
+	free_policy_node(ast);
+	cleanup_parsing();
+	fclose(f);
+
+}
+END_TEST
+
+START_TEST (test_disable_comment_if) {
+
+	set_current_module_name("disable_comment");
+
+	FILE *f = fopen(DISABLE_COMMENT_IF_FILENAME, "r");
+	ck_assert_ptr_nonnull(f);
+	struct policy_node *ast = yyparse_wrapper(f, DISABLE_COMMENT_IF_FILENAME, NODE_IF_FILE);
+	ck_assert_ptr_nonnull(ast);
+
+	ck_assert_ptr_nonnull(ast);
+	ck_assert_int_eq(NODE_IF_FILE, ast->flavor);
+	ck_assert_ptr_nonnull(ast->next);
+	ck_assert_int_eq(NODE_INTERFACE_DEF, ast->next->flavor);
+	ck_assert_str_eq("S-012", ast->next->exceptions);
+	ck_assert_ptr_null(ast->next->next);
 
 	free_policy_node(ast);
 	cleanup_parsing();
@@ -831,7 +855,8 @@ static Suite *parsing_suite(void) {
 	tcase_add_test(tc_core, test_parse_empty_file);
 	tcase_add_test(tc_core, test_syntax_error);
 	tcase_add_test(tc_core, test_parse_bad_role_allow);
-	tcase_add_test(tc_core, test_disable_comment);
+	tcase_add_test(tc_core, test_disable_comment_te);
+	tcase_add_test(tc_core, test_disable_comment_if);
 	tcase_add_test(tc_core, test_bool_declarations);
 	tcase_add_test(tc_core, test_file_flavor_mismatch);
 	tcase_add_test(tc_core, test_extended_perms);

--- a/tests/sample_policy_files/disable_comment.if
+++ b/tests/sample_policy_files/disable_comment.if
@@ -1,0 +1,3 @@
+interface(`foo', ` #selint-disable:S-012
+	# empty
+')


### PR DESCRIPTION
Allow to ignore selint findings on interface and template definitions:

    interface(`foo' ,` #selint-disable:S-012
        ...