### PR TITLE
Allow { in defines in .te files

### DIFF
--- a/src/parse.y
+++ b/src/parse.y
@@ -670,6 +670,10 @@ m4_string_elem:
 	|
 	CLOSE_PAREN
 	|
+	OPEN_CURLY
+	|
+	CLOSE_CURLY
+	|
 	COMMA
 	|
 	PERIOD

--- a/tests/sample_policy_files/uncommon.te
+++ b/tests/sample_policy_files/uncommon.te
@@ -76,6 +76,8 @@ gen_tunable(hello,world)
 
 define(yes, no)
 
+define(`list_of_things', `{ thing1 thing2 }')
+
 typebounds foo_t bar_t;
 
 call_with_backtick_args(foo_t,bar_t,`in')


### PR DESCRIPTION
Currently
```
define(`something', `{ thing1 thing2 }')
```
leads to an parser error because the curly braces are not allowed in the
second argument of the definition. As this seems to work in practise,
this seems like a parser problem to me. This commit allow the curly braces
to be used in these definitions.
