### PR TITLE
Check attribute names in declarations

### DIFF
--- a/src/if_checks.c
+++ b/src/if_checks.c
@@ -287,6 +287,10 @@ struct check_result *check_name_used_but_not_required_in_if(const struct
 	}
 
 	const struct string_list *name_node = names_in_current_node;
+	/* In declarations skip the first name, which is the new declared type */
+	if (node->flavor == NODE_DECL) {
+		name_node = name_node->next;
+	}
 	const char *flavor = NULL;
 
 	while (name_node) {

--- a/src/parse_functions.c
+++ b/src/parse_functions.c
@@ -83,7 +83,8 @@ enum selint_error insert_comment(struct policy_node **cur, unsigned int lineno)
 }
 
 enum selint_error insert_declaration(struct policy_node **cur,
-                                     enum decl_flavor flavor, const char *name,
+                                     enum decl_flavor flavor,
+                                     const char *name,
                                      struct string_list *attrs,
                                      unsigned int lineno)
 {
@@ -98,7 +99,7 @@ enum selint_error insert_declaration(struct policy_node **cur,
 			// We are inside a template, so we need to save declarations in the template map
 			// 'role foo types bar_t, baz_t;' statements are not declarations.
 			insert_decl_into_template_map(temp_name, flavor, name);
-		} else if (name && '$' != name[0]) {
+		} else if ('$' != name[0]) {
 			// If the name starts with $ we're probably doing something like associating
 			// a role with types in interfaces
 
@@ -121,11 +122,7 @@ enum selint_error insert_declaration(struct policy_node **cur,
 	memset(data, 0, sizeof(struct declaration_data));
 
 	data->flavor = flavor;
-	if (name) {
-		data->name = strdup(name);
-	} else {
-		data->name = NULL;
-	}
+	data->name = strdup(name);
 	data->attrs = attrs;
 
 	union node_data nd;

--- a/src/runner.c
+++ b/src/runner.c
@@ -203,6 +203,7 @@ struct checks *register_checks(char level,
 			add_check(NODE_TYPE_ATTRIBUTE, ck, "W-001", check_no_explicit_declaration);
 			add_check(NODE_ROLE_ATTRIBUTE, ck, "W-001", check_no_explicit_declaration);
 			add_check(NODE_PERMISSIVE, ck, "W-001", check_no_explicit_declaration);
+			add_check(NODE_DECL, ck, "W-001", check_no_explicit_declaration);
 		}
 		if (CHECK_ENABLED("W-002")) {
 			add_check(NODE_AV_RULE, ck, "W-002", check_name_used_but_not_required_in_if);
@@ -217,6 +218,7 @@ struct checks *register_checks(char level,
 			add_check(NODE_TYPE_ATTRIBUTE, ck, "W-002", check_name_used_but_not_required_in_if);
 			add_check(NODE_ROLE_ATTRIBUTE, ck, "W-002", check_name_used_but_not_required_in_if);
 			add_check(NODE_PERMISSIVE, ck, "W-002", check_name_used_but_not_required_in_if);
+			add_check(NODE_DECL, ck, "W-002", check_name_used_but_not_required_in_if);
 		}
 		if (CHECK_ENABLED("W-003")) {
 			add_check(NODE_DECL, ck, "W-003",

--- a/src/te_checks.c
+++ b/src/te_checks.c
@@ -425,7 +425,13 @@ struct check_result *check_no_explicit_declaration(const struct check_data *data
 
 	struct string_list *names = get_names_in_node(node);
 
-	for (const struct string_list *name = names; name; name = name->next) {
+	const struct string_list *name = names;
+	/* In declarations skip the first name, which is the new declared type */
+	if (node->flavor == NODE_DECL) {
+		name = name->next;
+	}
+
+	for (; name; name = name->next) {
 		const char *mod_name;
 		enum decl_flavor flavor;
 

--- a/src/tree.c
+++ b/src/tree.c
@@ -218,12 +218,8 @@ struct string_list *get_names_in_node(const struct policy_node *node)
 
 	case NODE_DECL:
 		d_data = node->data.d_data;
-		if (d_data->name) {
-			ret = sl_from_str(d_data->name);
-			ret->next = copy_string_list(d_data->attrs);
-		} else {
-			ret = copy_string_list(d_data->attrs);
-		}
+		ret = sl_from_str(d_data->name);
+		ret->next = copy_string_list(d_data->attrs);
 		break;
 
 	case NODE_IF_CALL:

--- a/tests/functional/end-to-end.bats
+++ b/tests/functional/end-to-end.bats
@@ -193,7 +193,7 @@ test_parse_error_impl() {
 }
 
 @test "W-002" {
-	test_one_check "W-002" "w02.*"
+	test_one_check_expect "W-002" "w02.*" 2
 	test_one_check "W-002" "w02_role.*"
 }
 

--- a/tests/functional/policies/check_triggers/w02.if
+++ b/tests/functional/policies/check_triggers/w02.if
@@ -6,3 +6,7 @@ interface(`foo_do_things',`
 	allow $1 foo_conf_t:file read;
 	read_files_pattern($1, bin_t, bin_t)
 ')
+
+template(`foo_attr_in_type_decl',`
+	type $1_foo_t, foo_attr;
+')

--- a/tests/functional/policies/check_triggers/w02.te
+++ b/tests/functional/policies/check_triggers/w02.te
@@ -1,3 +1,5 @@
 policy_module(w02, 1.0)
 
+attribute foo_attr;
+
 type bin_t;


### PR DESCRIPTION
For declarations in interfaces like

    type foo_t, bar_attr;

also include in checks W-001 and W-002 the attribute bar_attr.

See https://github.com/SELinuxProject/refpolicy/pull/384

ssh.if:             172: (W): Attribute ssh_server is used in interface but not required (W-002)
Found the following issue counts:
W-002: 1