### PR TITLE
Add checks regarding conditional expression identifiers

### DIFF
--- a/README
+++ b/README
@@ -161,6 +161,7 @@ CHECK IDS
 	C-005: Permissions in av rule or class declaration not ordered
 	C-006: Declarations in require block not ordered
 	C-007: Redudant type specification instead of self keyword
+	C-008: Conditional expression identifier from foreign module
 
 	S-001: Require block used instead of interface call
 	S-002: File context file labels with type not declared in module
@@ -184,6 +185,7 @@ CHECK IDS
 	W-009: Module name does not match file name
 	W-010: Call to unknown interface
 	W-011: Declaration in require block not defined in own module
+	W-012: Conditional expression contains unknown identifier
 
 	E-002: Bad file context format
 	E-003: Nonexistent user listed in fc file

--- a/src/check_hooks.h
+++ b/src/check_hooks.h
@@ -32,6 +32,7 @@ enum convention_ids {
 	C_ID_UNORDERED_PERM = 5,
 	C_ID_UNORDERED_REQ  = 6,
 	C_ID_SELF           = 7,
+	C_ID_FOREIGN_CONDID = 8,
 	C_END
 };
 
@@ -61,6 +62,7 @@ enum warn_ids {
 	W_ID_MOD_NAME_FILE     = 9,
 	W_ID_UNKNOWN_CALL      = 10,
 	W_ID_IF_DECL_NOT_OWN   = 11,
+	W_ID_UNKNOWN_COND_ID   = 12,
 	W_END
 };
 

--- a/src/ordering.c
+++ b/src/ordering.c
@@ -193,6 +193,7 @@ const char *get_section(const struct policy_node *node)
 	case NODE_FC_FILE:
 	case NODE_SPT_FILE:
 	case NODE_AV_FILE:
+	case NODE_COND_FILE:
 		return NULL; // Should never happen
 	case NODE_HEADER:
 		return SECTION_NON_ORDERED; // Guaranteed at top by grammar

--- a/src/parse_functions.c
+++ b/src/parse_functions.c
@@ -611,8 +611,12 @@ enum selint_error end_optional_else(struct policy_node **cur)
 enum selint_error begin_boolean_policy(struct policy_node **cur,
                                        unsigned int lineno)
 {
+	struct cond_declaration_data *cd_data = malloc(sizeof(struct cond_declaration_data));
+	cd_data->identifiers = NULL;;
+
 	union node_data nd;
-	nd.str = NULL;
+	nd.cd_data = cd_data;
+
 	return begin_block(cur, NODE_BOOLEAN_POLICY, nd, lineno);
 }
 
@@ -625,8 +629,12 @@ enum selint_error end_boolean_policy(struct policy_node **cur)
 enum selint_error begin_tunable_policy(struct policy_node **cur,
                                        unsigned int lineno)
 {
+	struct cond_declaration_data *cd_data = malloc(sizeof(struct cond_declaration_data));
+	cd_data->identifiers = NULL;;
+
 	union node_data nd;
-	nd.str = NULL;
+	nd.cd_data = cd_data;
+
 	return begin_block(cur, NODE_TUNABLE_POLICY, nd, lineno);
 }
 
@@ -757,6 +765,23 @@ enum selint_error save_command(struct policy_node *cur, const char *comm)
 	} else {
 		return SELINT_PARSE_ERROR;
 	}
+
+	return SELINT_SUCCESS;
+}
+
+enum selint_error save_identifier(struct policy_node *cur, char *identifier)
+{
+	if (cur == NULL || identifier == NULL) {
+		free(identifier);
+		return SELINT_BAD_ARG;
+	}
+
+	if (cur->flavor != NODE_TUNABLE_POLICY && cur->flavor != NODE_BOOLEAN_POLICY) {
+		free(identifier);
+		return SELINT_BAD_ARG;
+	}
+
+	cur->data.cd_data->identifiers = concat_string_lists(cur->data.cd_data->identifiers, sl_from_str_consume(identifier));
 
 	return SELINT_SUCCESS;
 }

--- a/src/parse_functions.h
+++ b/src/parse_functions.h
@@ -358,6 +358,17 @@ enum selint_error end_m4_argument(struct policy_node **cur);
 enum selint_error save_command(struct policy_node *cur, const char *comm);
 
 /**********************************
+* save_identifier
+* Save an identifier name in the tree.
+* cur (in) - The current spot in the tree.  Will be modified with information
+* about the identifier
+* comm (in, sink) - The name of the identifier
+*
+* Returns - SELint error code
+**********************************/
+enum selint_error save_identifier(struct policy_node *cur, char *identifier);
+
+/**********************************
 * insert_type_attribute
 * Insert a type_attribute node into the tree
 * cur (in, out) - The current spot in the tree.  Will be updated to point to the

--- a/src/runner.c
+++ b/src/runner.c
@@ -153,6 +153,12 @@ struct checks *register_checks(char level,
 			add_check(NODE_XAV_RULE, ck, "C-007",
 			          check_no_self);
 		}
+		if (CHECK_ENABLED("C-008")) {
+			add_check(NODE_BOOLEAN_POLICY, ck, "C-008",
+			          check_foreign_cond_id);
+			add_check(NODE_TUNABLE_POLICY, ck, "C-008",
+			          check_foreign_cond_id);
+		}
 		// FALLTHRU
 	case 'S':
 		if (CHECK_ENABLED("S-001")) {
@@ -261,6 +267,12 @@ struct checks *register_checks(char level,
 		if (CHECK_ENABLED("W-011")) {
 			add_check(NODE_DECL, ck, "W-011",
 				  check_required_declaration_own);
+		}
+		if (CHECK_ENABLED("W-012")) {
+			add_check(NODE_BOOLEAN_POLICY, ck, "W-012",
+				  check_unknown_cond_id);
+			add_check(NODE_TUNABLE_POLICY, ck, "W-012",
+				  check_unknown_cond_id);
 		}
 		// FALLTHRU
 	case 'E':

--- a/src/startup.h
+++ b/src/startup.h
@@ -19,6 +19,7 @@
 
 #include "selint_error.h"
 #include "file_list.h"
+#include "string_list.h"
 
 enum selint_error load_access_vectors_kernel(const char *av_path);
 
@@ -31,6 +32,8 @@ enum selint_error load_modules_source(const char *modules_conf_path);
 enum selint_error load_obj_perm_sets_source(const char *obj_perm_sets_path);
 
 enum selint_error load_devel_headers(struct policy_file_list *context_files);
+
+enum selint_error load_global_conditions(const struct string_list *paths);
 
 enum selint_error mark_transform_interfaces(const struct policy_file_list *files);
 

--- a/src/te_checks.h
+++ b/src/te_checks.h
@@ -59,6 +59,18 @@ struct check_result *check_no_self(const struct check_data *data,
                                    const struct policy_node *node);
 
 /*********************************************
+ * Check for identifiers in conditional expressions not declared in own module.
+ * Called on NODE_BOOLEAN_POLICY and NODE_TUNABLE_POLICY nodes.
+ * data - metadata about the file currently being scanned
+ * node - the node to check
+ * returns NULL if passed or check_result for issue C-008
+*********************************************/
+struct check_result *check_foreign_cond_id(const struct check_data
+                                           *data,
+                                           const struct policy_node
+                                           *node);
+
+/*********************************************
 * Check for the presence of require blocks in TE files.
 * Interface calls are to be preferred.
 * Called on NODE_REQUIRE and NODE_GEN_REQ nodes.
@@ -195,6 +207,18 @@ struct check_result *check_unknown_interface_call(const struct check_data
                                                   *data,
                                                   const struct policy_node
                                                   *node);
+
+/*********************************************
+ * Check for unknown identifiers in conditional expressions.
+ * Called on NODE_BOOLEAN_POLICY and NODE_TUNABLE_POLICY nodes.
+ * data - metadata about the file currently being scanned
+ * node - the node to check
+ * returns NULL if passed or check_result for issue W-012
+*********************************************/
+struct check_result *check_unknown_cond_id(const struct check_data
+                                           *data,
+                                           const struct policy_node
+                                           *node);
 
 /*********************************************
  * Check for clash of declaration and interface names.

--- a/src/tree.c
+++ b/src/tree.c
@@ -261,6 +261,7 @@ struct string_list *get_names_in_node(const struct policy_node *node)
 	   NODE_FC_FILE,
 	   NODE_SPT_FILE,
 	   NODE_AV_FILE,
+	   NODE_COND_FILE,
 	   NODE_HEADER,
 	   NODE_M4_CALL,
 	   NODE_M4_SIMPLE_MACRO,
@@ -398,6 +399,10 @@ enum selint_error free_policy_node(struct policy_node *to_free)
 		break;
 	case NODE_GEN_REQ:
 		free_gen_require_data(to_free->data.gr_data);
+		break;
+	case NODE_BOOLEAN_POLICY:
+	case NODE_TUNABLE_POLICY:
+		free_cond_declaration_data(to_free->data.cd_data);
 		break;
 	default:
 		if (to_free->data.str != NULL) {
@@ -629,5 +634,11 @@ void free_attribute_data(struct attribute_data *to_free)
 
 void free_gen_require_data(struct gen_require_data *to_free)
 {
+	free(to_free);
+}
+
+void free_cond_declaration_data(struct cond_declaration_data *to_free)
+{
+	free_string_list(to_free->identifiers);
 	free(to_free);
 }

--- a/src/tree.h
+++ b/src/tree.h
@@ -26,6 +26,7 @@ enum node_flavor {
 	NODE_FC_FILE,
 	NODE_SPT_FILE,
 	NODE_AV_FILE,
+	NODE_COND_FILE,
 	NODE_AV_RULE,
 	NODE_XAV_RULE,
 	NODE_TT_RULE,
@@ -195,6 +196,10 @@ struct gen_require_data {
 	unsigned char unquoted;
 };
 
+struct cond_declaration_data {
+	struct string_list *identifiers;
+};
+
 union node_data {
 	struct header_data *h_data;
 	struct av_rule_data *av_data;
@@ -208,6 +213,7 @@ union node_data {
 	struct fc_entry *fc_data;
 	struct attribute_data *at_data;
 	struct gen_require_data *gr_data;
+	struct cond_declaration_data *cd_data;
 	char *str;
 };
 
@@ -284,5 +290,7 @@ void free_sel_context(struct sel_context *to_free);
 void free_attribute_data(struct attribute_data *to_free);
 
 void free_gen_require_data(struct gen_require_data *to_free);
+
+void free_cond_declaration_data(struct cond_declaration_data *to_free);
 
 #endif

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -132,6 +132,8 @@ FUNCTIONAL_TEST_FILES=functional/end-to-end.bats \
 			functional/policies/check_triggers/c06.warn.if \
 			functional/policies/check_triggers/c07.te \
 			functional/policies/check_triggers/c07.if \
+			functional/policies/check_triggers/c08.te \
+			functional/policies/check_triggers/c08_other.te \
 			functional/policies/check_triggers/e02.fc \
 			functional/policies/check_triggers/e03e04e05.fc \
 			functional/policies/check_triggers/e06.te \
@@ -181,6 +183,7 @@ FUNCTIONAL_TEST_FILES=functional/end-to-end.bats \
 			functional/policies/check_triggers/w10.warn.te \
 			functional/policies/check_triggers/w11.te \
 			functional/policies/check_triggers/w11.if \
+			functional/policies/check_triggers/w12.te \
 			functional/policies/check_triggers/x01.if \
 			functional/policies/check_triggers/x01.te \
 			functional/policies/check_triggers/C-001/interleaved.expect.ref \

--- a/tests/functional/end-to-end.bats
+++ b/tests/functional/end-to-end.bats
@@ -156,6 +156,10 @@ test_parse_error_impl() {
 	test_one_check "C-007" "c07.if"
 }
 
+@test "C-008" {
+	test_one_check "C-008" "c08*.te"
+}
+
 @test "S-001" {
 	test_one_check "S-001" "s01.te"
 }
@@ -244,6 +248,10 @@ test_parse_error_impl() {
 
 @test "W-011" {
 	test_one_check "W-011" "w11.*"
+}
+
+@test "W-012" {
+	test_one_check "W-012" "w12.te"
 }
 
 @test "E-002" {

--- a/tests/functional/policies/check_triggers/c08.te
+++ b/tests/functional/policies/check_triggers/c08.te
@@ -1,0 +1,5 @@
+policy_module(c08, 1.0)
+
+type foo_t;
+
+bool c08_cond;

--- a/tests/functional/policies/check_triggers/c08_other.te
+++ b/tests/functional/policies/check_triggers/c08_other.te
@@ -1,0 +1,13 @@
+policy_module(c08_other, 1.0)
+
+type bar_t;
+
+bool c08_other_cond;
+
+if (c08_other_cond) {
+	allow bar_t self:process fork;
+}
+
+if (c08_cond) {
+	allow bar_t self:process fork;
+}

--- a/tests/functional/policies/check_triggers/w12.te
+++ b/tests/functional/policies/check_triggers/w12.te
@@ -1,0 +1,13 @@
+policy_module(w12, 1.0)
+
+type bar_t;
+
+bool w12_cond;
+
+if (w12_cond) {
+	allow bar_t self:process fork;
+}
+
+if (w12_cond && foo) {
+	allow bar_t self:process fork;
+}


### PR DESCRIPTION
Check each identifier is known.
Check each identifier is declared in own module or globally.

Refpolicy findings:

    mplayer.te:         122: (C): Identifier xserver_allow_dri in expression for conditional block not found in own module, but in module xserver (candidate for global declaration or interface) (C-008)
    xguest.te:           44: (C): Identifier user_exec_noexattrfile in expression for conditional block not found in own module, but in module userdomain (candidate for global declaration or interface) (C-008)
    xguest.te:           48: (C): Identifier user_rw_noexattrfile in expression for conditional block not found in own module, but in module userdomain (candidate for global declaration or interface) (C-008)
    nscd.te:            125: (C): Identifier samba_domain_controller in expression for conditional block not found in own module, but in module samba (candidate for global declaration or interface) (C-008)
    usermanage.te:      578: (C): Identifier samba_domain_controller in expression for conditional block not found in own module, but in module samba (candidate for global declaration or interface) (C-008)
    userdomain.if:     1236: (C): Identifier usbguard_user_modify_rule_files in expression for conditional block not found in own module, but in module usbguard (candidate for global declaration or interface) (C-008)
    Found the following issue counts:
    C-008: 6