### PR TITLE
Accept MLS ranges as interface argument

### DIFF
--- a/src/parse.y
+++ b/src/parse.y
@@ -724,7 +724,7 @@ arg:
 	|
 	QUOTED_STRING { $$ = sl_from_str_consume($1); }
 	|
-	BACKTICK strings SINGLE_QUOTE { $$ = $2; }
+	BACKTICK mls_range SINGLE_QUOTE { $$ = sl_from_str_consume($2); }
 	|
 	BACKTICK SINGLE_QUOTE { $$ = sl_from_str(""); }
 	;

--- a/src/parse.y
+++ b/src/parse.y
@@ -434,6 +434,8 @@ xperm_items:
 	xperm_items xperm_item { $$ = concat_string_lists($1, sl_from_str($2)); free($2); }
 	|
 	xperm_item { $$ = sl_from_str_consume($1); }
+	|
+	xperm_item DASH xperm_item { $$ = concat_string_lists(sl_from_str_consume($1), concat_string_lists(sl_from_str("-"), sl_from_str_consume($3))); } // TODO: validate usage: enforce two surrounding increasing elements
 	;
 
 xperm_item:
@@ -442,8 +444,6 @@ xperm_item:
 	NUM_STRING { $$ = $1; }
 	|
 	NUMBER { $$ = $1; }
-	|
-	DASH { $$ = strdup("-"); }  // TODO: validate usage: enforce two surrounding increasing elements
 	;
 
 string_list:

--- a/tests/sample_policy_files/uncommon.te
+++ b/tests/sample_policy_files/uncommon.te
@@ -129,3 +129,8 @@ define(`foobar')
 ifelse(`$1',,, `
     refpolicywarn(`dollar one defined')
 ')
+
+example_interface(foo_t, `s0:c0')
+example_interface(foo_t, `s15:c100.c102')
+range_transition foo_t foo_t:file s0:c0 - s15:c100.c102;
+example_interface(foo_t, `s0:c0 - s15:c100.c102')


### PR DESCRIPTION
Accept MLS ranges as single quoted arguments to interface calls, like:

    bar(foo_t, `s0:c0 - s15:c2.c3')

The dash needs to be surrounded by spaces, otherwise it gets consumed in
the preceding identifier (as '-' is a valid identifier character).

The whole range needs to be single quoted to avoid a grammar conflict
with a trailing string starting with a dash and not separated by a
comma, e.g.:

   bar(foo_t, s0 -somestring)

or with a single extended permission.

To avoid another collision `strings` have been removed from `args`,
introduced in 3deb9f6, but there seems to be no regression.

Closes: #213 

