### PR TITLE
Support IPv4/IPv6 address embedding

### DIFF
--- a/src/lex.l
+++ b/src/lex.l
@@ -154,7 +154,7 @@ userdebug_or_eng { return USERDEBUG_OR_ENG; }
 [a-zA-Z\$\/][a-zA-Z0-9_\$\*\/\-]* { yylval->string = strdup(yytext); return STRING; }
 [0-9a-zA-Z\$\/][a-zA-Z0-9_\$\*\/\-]* { yylval->string = strdup(yytext); return NUM_STRING; }
 [0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3} { yylval->string = strdup(yytext); return IPV4; }
-([0-9A-Fa-f]{1,4})?\:([0-9A-Fa-f\:])*\:([0-9A-Fa-f]{1,4})? { yylval->string = strdup(yytext); return IPV6; }
+([0-9A-Fa-f]{1,4})?\:([0-9A-Fa-f\:])*\:([0-9A-Fa-f]{1,4})?(\:[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})? { yylval->string = strdup(yytext); return IPV6; }
 \"[a-zA-Z0-9_\.\-\:~\$]*\" { yylval->string = strdup(yytext); return QUOTED_STRING; }
 \-[\-ldbcsp][ \t] { return FILE_TYPE_SPECIFIER; }
 \( { return OPEN_PAREN; }

--- a/tests/sample_policy_files/uncommon.te
+++ b/tests/sample_policy_files/uncommon.te
@@ -46,6 +46,7 @@ netifcon lo gen_context(system_u:object_r:lo_netif_t,s0 - mls_systemhigh) gen_co
 
 nodecon 127.0.0.1 255.255.255.255 gen_context(system_u:object_r:system_t:s0)
 nodecon ::5 ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff gen_context(system_u:object_r:system_t:s0)
+nodecon ::ffff:127.0.0.1 ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff gen_context(system_u:object_r:lo_node_t,s0)
 
 if (!bool_one) {
 	allow foo_t bar_t:file open;


### PR DESCRIPTION
Accept IPv4 addresses embedded in IPv6, like `::ffff:127.0.0.1`.
This allows using those in nodecon statements.