### PR TITLE
Support policy_module macro without version

### DIFF
--- a/src/parse.y
+++ b/src/parse.y
@@ -237,10 +237,10 @@ maybe_selint_disable:
 
 
 header:
-	POLICY_MODULE OPEN_PAREN STRING COMMA header_version CLOSE_PAREN {
+	POLICY_MODULE OPEN_PAREN STRING maybe_header_version CLOSE_PAREN {
 			if (expected_node_flavor != NODE_TE_FILE) {
 				free($3);
-				const struct location loc = { @1.first_line, @1.first_column, @6.last_line, @6.last_column };
+				const struct location loc = { @1.first_line, @1.first_column, @5.last_line, @5.last_column };
 				yyerror(&loc, NULL, "Error: Unexpected te-file parsed"); YYERROR;
 			}
 			insert_header(&cur, $3, HEADER_MACRO, @$.first_line); free($3); } // Version number isn't needed
@@ -258,6 +258,12 @@ header_version:
 	VERSION_NO { free($1); }
 	|
 	NUMBER { free($1); }
+	;
+
+maybe_header_version:
+	COMMA header_version
+	|
+	%empty
 	;
 
 body:

--- a/tests/sample_policy_files/basic.te
+++ b/tests/sample_policy_files/basic.te
@@ -1,4 +1,4 @@
-policy_module(basic, 1.0)
+policy_module(basic)
 
 type basic_t;
 


### PR DESCRIPTION
Refpolicy dropped the version information from the policy_module macro
and just uses the macro now with only the module name.

https://github.com/SELinuxProject/refpolicy/commit/78276fc43b76277399f38028b4a2904b3b541e6c
https://github.com/SELinuxProject/refpolicy/pull/456