### PR TITLE
Check for argument counter of zero

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -364,7 +364,7 @@ int main(int argc, char **argv)
 
 	print_if_verbose("Severity level set to %c\n", severity);
 
-	if (optind == argc) {
+	if (optind >= argc) {
 		usage();
 		exit(EX_USAGE);
 	}


### PR DESCRIPTION
Reject invocations with an argument counter of zero, in which case the
subsequent allocation

    char **paths = malloc(sizeof(char *) * (unsigned)argc - (unsigned)optind + 2);

will cause a crash in fts_read(3).