### PR TITLE
Allow square brackets in quoted strings for anon inodes

### DIFF
--- a/src/lex.l
+++ b/src/lex.l
@@ -155,7 +155,7 @@ userdebug_or_eng { return USERDEBUG_OR_ENG; }
 [0-9a-zA-Z\$\/][a-zA-Z0-9_\$\*\/\-]* { yylval->string = strdup(yytext); return NUM_STRING; }
 [0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3} { yylval->string = strdup(yytext); return IPV4; }
 ([0-9A-Fa-f]{1,4})?\:([0-9A-Fa-f\:])*\:([0-9A-Fa-f]{1,4})?(\:[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})? { yylval->string = strdup(yytext); return IPV6; }
-\"[a-zA-Z0-9_\.\-\:~\$]*\" { yylval->string = strdup(yytext); return QUOTED_STRING; }
+\"[a-zA-Z0-9_\.\-\:~\$\[\]]*\" { yylval->string = strdup(yytext); return QUOTED_STRING; }
 \-[\-ldbcsp][ \t] { return FILE_TYPE_SPECIFIER; }
 \( { return OPEN_PAREN; }
 \) { return CLOSE_PAREN; }

--- a/tests/sample_policy_files/uncommon.te
+++ b/tests/sample_policy_files/uncommon.te
@@ -135,3 +135,6 @@ example_interface(foo_t, `s0:c0')
 example_interface(foo_t, `s15:c100.c102')
 range_transition foo_t foo_t:file s0:c0 - s15:c100.c102;
 example_interface(foo_t, `s0:c0 - s15:c100.c102')
+
+type_transition foo_t foo_t : anon_inode bar_t "[userfaultfd]";
+anoninodetrans_pattern(foo_t, bar_t, "[io_uring]")


### PR DESCRIPTION
Anonymous inode class names are enclosed by square brackets and are used in name base type transitions.
Example from https://github.com/torvalds/linux/commit/29cd6591ab6fee3125ea5c1bf350f5013bc615e1:

    type_transition sysadm_t sysadm_t : anon_inode uffd_t "[userfaultfd]";