### PR TITLE
CI: bump to LLVM version 13 and really use the desired Clang version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,9 +33,9 @@ jobs:
         if [[ ${{ matrix.cc }} == 'clang' ]]
         then
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key 2>/dev/null | sudo apt-key add -
-          sudo add-apt-repository 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-12 main' -y
+          sudo add-apt-repository 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main' -y
           sudo apt-get update -q
-          sudo apt-get install -y clang-12
+          sudo apt-get install -y clang-13
         fi
     - name: install dependencies
       run: |
@@ -67,7 +67,7 @@ jobs:
         then
           ./configure --enable-werror CFLAGS=--coverage
         else
-          ./configure --enable-werror
+          ./configure --enable-werror CC=clang-13
         fi
     - name: make
       run: make


### PR DESCRIPTION
Currently the Clang build uses default installed Clang version (11),
since the additional installed package does not override the default
command without a version suffix.