### PR TITLE
Avoid exceptions override

### DIFF
--- a/src/parse.y
+++ b/src/parse.y
@@ -578,40 +578,57 @@ require_lines:
 	;
 
 require_line:
-	require_bare maybe_selint_disable {
-		// Apply command to all declarations
-		for (struct policy_node *p = cur; p && p->flavor == NODE_DECL; p = p->prev) save_command(p, $2);
+	TYPE comma_string_list SEMICOLON maybe_selint_disable {
+		for (const struct string_list *iter = $2; iter; iter = iter->next) {
+			insert_declaration(&cur, DECL_TYPE, iter->string, NULL, @$.first_line);
+			save_command(cur, $4);
+		}
+		free_string_list($2);
+		free($4);
+		}
+	|
+	ATTRIBUTE comma_string_list SEMICOLON maybe_selint_disable {
+		for (const struct string_list *iter = $2; iter; iter = iter->next) {
+			insert_declaration(&cur, DECL_ATTRIBUTE, iter->string, NULL, @$.first_line);
+			save_command(cur, $4);
+		}
+		free_string_list($2);
+		free($4);
+		}
+	|
+	ROLE comma_string_list SEMICOLON maybe_selint_disable {
+		for (const struct string_list *iter = $2; iter; iter = iter->next) {
+			insert_declaration(&cur, DECL_ROLE, iter->string, NULL, @$.first_line);
+			save_command(cur, $4);
+		}
+		free_string_list($2);
+		free($4);
+		}
+	|
+	ATTRIBUTE_ROLE comma_string_list SEMICOLON maybe_selint_disable {
+		for (const struct string_list *iter = $2; iter; iter = iter->next) {
+			insert_declaration(&cur, DECL_ATTRIBUTE_ROLE, iter->string, NULL, @$.first_line);
+			save_command(cur, $4);
+		}
+		free_string_list($2);
+		free($4);
+		}
+	|
+	BOOL comma_string_list SEMICOLON maybe_selint_disable {
+		for (const struct string_list *iter = $2; iter; iter = iter->next) {
+			insert_declaration(&cur, DECL_BOOL, iter->string, NULL, @$.first_line);
+			save_command(cur, $4);
+		}
+		free_string_list($2);
+		free($4);
+		}
+	|
+	CLASS STRING string_list SEMICOLON maybe_selint_disable {
+		insert_declaration(&cur, DECL_CLASS, $2, $3, @$.first_line);
+		save_command(cur, $5);
 		free($2);
+		free($5);
 		}
-	;
-
-require_bare:
-	TYPE comma_string_list SEMICOLON {
-		for (const struct string_list *iter = $2; iter; iter = iter->next) insert_declaration(&cur, DECL_TYPE, iter->string, NULL, @$.first_line);
-		free_string_list($2);
-		}
-	|
-	ATTRIBUTE comma_string_list SEMICOLON {
-		for (const struct string_list *iter = $2; iter; iter = iter->next) insert_declaration(&cur, DECL_ATTRIBUTE, iter->string, NULL, @$.first_line);
-		free_string_list($2);
-		}
-	|
-	ROLE comma_string_list SEMICOLON {
-		for (const struct string_list *iter = $2; iter; iter = iter->next) insert_declaration(&cur, DECL_ROLE, iter->string, NULL, @$.first_line);
-		free_string_list($2);
-		}
-	|
-	ATTRIBUTE_ROLE comma_string_list SEMICOLON {
-		for (const struct string_list *iter = $2; iter; iter = iter->next) insert_declaration(&cur, DECL_ATTRIBUTE_ROLE, iter->string, NULL, @$.first_line);
-		free_string_list($2);
-		}
-	|
-	BOOL comma_string_list SEMICOLON {
-		for (const struct string_list *iter = $2; iter; iter = iter->next) insert_declaration(&cur, DECL_BOOL, iter->string, NULL, @$.first_line);
-		free_string_list($2);
-		}
-	|
-	CLASS STRING string_list SEMICOLON { insert_declaration(&cur, DECL_CLASS, $2, $3, @$.first_line); free($2); }
 	|
 	if_or_ifn OPEN_PAREN BACKTICK STRING SINGLE_QUOTE COMMA BACKTICK { begin_ifdef(&cur, @$.first_line); }
 	require_lines SINGLE_QUOTE CLOSE_PAREN { end_ifdef(&cur); free($4); }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -104,6 +104,7 @@ SAMPLE_POLICY_FILES=sample_policy_files/access_vectors \
 			sample_policy_files/declaring_template.te \
 			sample_policy_files/disable_comment.if \
 			sample_policy_files/disable_comment.te \
+			sample_policy_files/disable_require.if \
 			sample_policy_files/empty.te \
 			sample_policy_files/extended_perms.te \
 			sample_policy_files/ifdef_block.te \

--- a/tests/check_parsing.c
+++ b/tests/check_parsing.c
@@ -31,6 +31,7 @@
 #define BAD_RA_FILENAME POLICIES_DIR "bad_role_allow.te"
 #define DISABLE_COMMENT_TE_FILENAME POLICIES_DIR "disable_comment.te"
 #define DISABLE_COMMENT_IF_FILENAME POLICIES_DIR "disable_comment.if"
+#define DISABLE_REQUIRE_IF_FILENAME POLICIES_DIR "disable_require.if"
 #define BOOL_DECLARATION_FILENAME POLICIES_DIR "bool_declarations.te"
 #define EXTENDED_TE_FILENAME POLICIES_DIR "extended_perms.te"
 #define IFDEF_BLOCK_FILENAME POLICIES_DIR "ifdef_block.te"
@@ -401,6 +402,138 @@ START_TEST (test_disable_comment_if) {
 	ck_assert_str_eq("S-012", ast->next->exceptions);
 	ck_assert_ptr_null(ast->next->next);
 
+	free_policy_node(ast);
+	cleanup_parsing();
+	fclose(f);
+
+}
+END_TEST
+
+START_TEST (test_disable_require_if) {
+
+	set_current_module_name("disable_require");
+
+	FILE *f = fopen(DISABLE_REQUIRE_IF_FILENAME, "r");
+	ck_assert_ptr_nonnull(f);
+	struct policy_node *ast = yyparse_wrapper(f, DISABLE_REQUIRE_IF_FILENAME, NODE_IF_FILE);
+	ck_assert_ptr_nonnull(ast);
+
+	const struct policy_node *current = ast;
+
+	// top file node
+	ck_assert_ptr_nonnull(current);
+	ck_assert_int_eq(NODE_IF_FILE, current->flavor);
+	ck_assert_ptr_null(current->first_child);
+	ck_assert_ptr_null(current->exceptions);
+	ck_assert_ptr_nonnull(current->next);
+
+	// first interface
+	current = current->next;
+	ck_assert_int_eq(NODE_INTERFACE_DEF, current->flavor);
+	ck_assert_str_eq("foo1", current->data.str);
+	ck_assert_ptr_null(current->exceptions);
+	ck_assert_ptr_nonnull(current->first_child);
+
+	// start block
+	current = current->first_child;
+	ck_assert_int_eq(NODE_START_BLOCK, current->flavor);
+	ck_assert_ptr_null(current->exceptions);
+	ck_assert_ptr_null(current->first_child);
+	ck_assert_ptr_nonnull(current->next);
+
+	// require block
+	current = current->next;
+	ck_assert_int_eq(NODE_GEN_REQ, current->flavor);
+	ck_assert_ptr_null(current->exceptions);
+	ck_assert_ptr_null(current->next);
+	ck_assert_ptr_nonnull(current->first_child);
+
+	// start block
+	current = current->first_child;
+	ck_assert_int_eq(NODE_START_BLOCK, current->flavor);
+	ck_assert_ptr_null(current->exceptions);
+	ck_assert_ptr_null(current->first_child);
+	ck_assert_ptr_nonnull(current->next);
+
+	// first declaration
+	current = current->next;
+	ck_assert_int_eq(NODE_DECL, current->flavor);
+	ck_assert_int_eq(DECL_CLASS, current->data.d_data->flavor);
+	ck_assert_str_eq("bar1_c", current->data.d_data->name);
+	ck_assert_ptr_nonnull(current->data.d_data->attrs);
+	ck_assert_str_eq(" W-010", current->exceptions);
+	ck_assert_ptr_null(current->first_child);
+	ck_assert_ptr_nonnull(current->next);
+
+	// second declaration
+	current = current->next;
+	ck_assert_int_eq(NODE_DECL, current->flavor);
+	ck_assert_int_eq(DECL_ROLE, current->data.d_data->flavor);
+	ck_assert_str_eq("bar1_r", current->data.d_data->name);
+	ck_assert_ptr_null(current->data.d_data->attrs);
+	ck_assert_str_eq(" W-011", current->exceptions);
+	ck_assert_ptr_null(current->first_child);
+	ck_assert_ptr_nonnull(current->next);
+
+	// third declaration
+	current = current->next;
+	ck_assert_int_eq(NODE_DECL, current->flavor);
+	ck_assert_int_eq(DECL_BOOL, current->data.d_data->flavor);
+	ck_assert_str_eq("bar1_b", current->data.d_data->name);
+	ck_assert_ptr_null(current->data.d_data->attrs);
+	ck_assert_str_eq(" W-012", current->exceptions);
+	ck_assert_ptr_null(current->first_child);
+	ck_assert_ptr_null(current->next);
+
+	// second interface
+	current = current->parent->parent->next;
+	ck_assert_int_eq(NODE_INTERFACE_DEF, current->flavor);
+	ck_assert_str_eq("foo2", current->data.str);
+	ck_assert_ptr_null(current->exceptions);
+	ck_assert_ptr_nonnull(current->first_child);
+
+	// start block
+	current = current->first_child;
+	ck_assert_int_eq(NODE_START_BLOCK, current->flavor);
+	ck_assert_ptr_null(current->exceptions);
+	ck_assert_ptr_null(current->first_child);
+	ck_assert_ptr_nonnull(current->next);
+
+	// require block
+	current = current->next;
+	ck_assert_int_eq(NODE_GEN_REQ, current->flavor);
+	ck_assert_ptr_null(current->exceptions);
+	ck_assert_ptr_null(current->next);
+	ck_assert_ptr_nonnull(current->first_child);
+
+	// start block
+	current = current->first_child;
+	ck_assert_int_eq(NODE_START_BLOCK, current->flavor);
+	ck_assert_ptr_null(current->exceptions);
+	ck_assert_ptr_null(current->first_child);
+	ck_assert_ptr_nonnull(current->next);
+
+	// first declaration
+	current = current->next;
+	ck_assert_int_eq(NODE_DECL, current->flavor);
+	ck_assert_int_eq(DECL_TYPE, current->data.d_data->flavor);
+	ck_assert_str_eq("bar3_t", current->data.d_data->name);
+	ck_assert_ptr_null(current->data.d_data->attrs);
+	ck_assert_str_eq(" W-011", current->exceptions);
+	ck_assert_ptr_null(current->first_child);
+	ck_assert_ptr_nonnull(current->next);
+
+	// second declaration
+	current = current->next;
+	ck_assert_int_eq(NODE_DECL, current->flavor);
+	ck_assert_int_eq(DECL_TYPE, current->data.d_data->flavor);
+	ck_assert_str_eq("bar4_t", current->data.d_data->name);
+	ck_assert_ptr_null(current->data.d_data->attrs);
+	ck_assert_str_eq(" W-011", current->exceptions);
+	ck_assert_ptr_null(current->first_child);
+	ck_assert_ptr_null(current->next);
+
+	// cleanup
 	free_policy_node(ast);
 	cleanup_parsing();
 	fclose(f);
@@ -935,6 +1068,7 @@ static Suite *parsing_suite(void) {
 	tcase_add_test(tc_core, test_parse_bad_role_allow);
 	tcase_add_test(tc_core, test_disable_comment_te);
 	tcase_add_test(tc_core, test_disable_comment_if);
+	tcase_add_test(tc_core, test_disable_require_if);
 	tcase_add_test(tc_core, test_bool_declarations);
 	tcase_add_test(tc_core, test_file_flavor_mismatch);
 	tcase_add_test(tc_core, test_extended_perms);

--- a/tests/sample_policy_files/disable_require.if
+++ b/tests/sample_policy_files/disable_require.if
@@ -1,0 +1,17 @@
+interface(`foo1', `
+	gen_require(`
+		class bar1_c { perm }; #selint-disable: W-010
+		role bar1_r; #selint-disable: W-011
+		bool bar1_b; #selint-disable: W-012
+	')
+
+	# empty
+')
+
+interface(`foo2', `
+	gen_require(`
+		type bar3_t, bar4_t; #selint-disable: W-011
+	')
+
+	#empty
+')


### PR DESCRIPTION
In a require block of

    gen_require(`
        type a; #selint-disable: W-010
        type b; #selint-disable: W-011
    ')

the SELint exceptions "W-011" will override "W-010" of the declaration
for type a and leak the previous one set.

Fixes: da6d80e7 ("Apply command to all declarations in a single require statement")