### PR TITLE
Print full paths

### DIFF
--- a/src/check_hooks.c
+++ b/src/check_hooks.c
@@ -26,6 +26,7 @@
 
 int found_issue = 0;
 int suppress_output = 0;
+int full_path = 0;
 
 #define ALLOC_NODE(nl)  if (ck->check_nodes[nl]) { \
 		loc = ck->check_nodes[nl]; \
@@ -93,18 +94,25 @@ enum selint_error call_checks_for_node_type(struct check_node *ck_list,
 void display_check_result(const struct check_result *res, const struct check_data *data)
 {
 	static const size_t FILENAME_PADDING = 22;
-
-	const size_t len = strlen(data->filename);
+	const char *name;
 	unsigned int padding;
 
-	if (FILENAME_PADDING < len) {
+	if (full_path) {
+		name = data->filepath;
 		padding = 0;
 	} else {
-		padding = (unsigned)(FILENAME_PADDING - len);
+		name = data->filename;
+		const size_t len = strlen(name);
+
+		if (FILENAME_PADDING < len) {
+			padding = 0;
+		} else {
+			padding = (unsigned)(FILENAME_PADDING - len);
+		}
 	}
 
 	printf("%s:%*u: %s(%c)%s: %s (%c-%03u)\n",
-	       data->filename,
+	       name,
 	       padding,
 	       res->lineno,
 	       color_severity(res->severity),

--- a/src/check_hooks.h
+++ b/src/check_hooks.h
@@ -93,6 +93,7 @@ enum file_flavor {
 
 struct check_data {
 	char *mod_name;
+	const char *filepath;
 	char *filename;
 	enum file_flavor flavor;
 	const struct config_check_data *config_check_data;
@@ -123,6 +124,8 @@ struct checks {
 extern int found_issue;
 // Whether found issues are printed individually
 extern int suppress_output;
+// Whether to print full paths
+extern int full_path;
 
 /*********************************************
 * Add an check to be called on check_flavor nodes

--- a/src/main.c
+++ b/src/main.c
@@ -38,6 +38,7 @@
 #define SUMMARY_ONLY_ID     130
 #define SCAN_HIDDEN_DIRS_ID 131
 #define DEBUG_PARSER_ID     132
+#define FULL_PATH_ID        133
 
 extern int yydebug;
 
@@ -64,6 +65,7 @@ static void usage(void)
 		"  -e, --enable=CHECKID\t\tEnable check with the given ID.\n"\
 		"  -E, --only-enabled\t\tOnly run checks that are explicitly enabled with\n"\
 		"\t\t\t\tthe --enable option.\n"\
+		"      --full-path\t\tPrint full path for files.\n"\
 		"  -F, --fail\t\t\tExit with a non-zero value if any issue was found.\n"\
 		"  -h, --help\t\t\tDisplay this menu.\n"\
 		"  -l, --level=LEVEL\t\tOnly list errors with a severity level at or\n"\
@@ -125,6 +127,7 @@ int main(int argc, char **argv)
 			{ "disable",          required_argument, NULL,          'd' },
 			{ "enable",           required_argument, NULL,          'e' },
 			{ "fail",             no_argument,       NULL,          'F' },
+			{ "full-path",        no_argument,       NULL,          FULL_PATH_ID },
 			{ "only-enabled",     no_argument,       NULL,          'E' },
 			{ "help",             no_argument,       NULL,          'h' },
 			{ "level",            required_argument, NULL,          'l' },
@@ -223,6 +226,11 @@ int main(int argc, char **argv)
 		case 'E':
 			// Only run checks enabled by the --enable flag.
 			only_enabled = 1;
+			break;
+
+		case FULL_PATH_ID:
+			// Display full paths for files
+			full_path = true;
 			break;
 
 		case 'F':

--- a/src/parse.y
+++ b/src/parse.y
@@ -1173,12 +1173,14 @@ static void yyerror(const YYLTYPE *locp, __attribute__((unused)) yyscan_t scanne
 		struct check_result *res = make_check_result('F', F_ID_POLICY_SYNTAX, "%s", msg);
 		res->lineno = locp->first_line;
 
-		struct check_data data;
-		data.mod_name = get_current_module_name();
 IGNORE_CONST_DISCARD_BEGIN
-		data.filename = parsing_filename;
+		struct check_data data = {
+			.mod_name = get_current_module_name(),
+			.filepath = parsing_filename,
+			.filename = parsing_filename, // Always print full path on errors
+			.flavor = FILE_TE_FILE, // We don't know but it's unused by display_check_result
+		};
 IGNORE_CONST_DISCARD_END
-		data.flavor = FILE_TE_FILE; // We don't know but it's unused by display_check_result
 
 		display_check_result(res, &data);
 

--- a/src/parse.y
+++ b/src/parse.y
@@ -1175,13 +1175,13 @@ static void yyerror(const YYLTYPE *locp, __attribute__((unused)) yyscan_t scanne
 
 		struct check_data data;
 		data.mod_name = get_current_module_name();
-		char *copy = xstrdup(parsing_filename);
-		data.filename = basename(copy);
+IGNORE_CONST_DISCARD_BEGIN
+		data.filename = parsing_filename;
+IGNORE_CONST_DISCARD_END
 		data.flavor = FILE_TE_FILE; // We don't know but it's unused by display_check_result
 
 		display_check_result(res, &data);
 
-		free(copy);
 		free_check_result(res);
 	}
 

--- a/src/runner.c
+++ b/src/runner.c
@@ -406,6 +406,7 @@ enum selint_error run_all_checks(struct checks *ck, enum file_flavor flavor,
 			free(copy);
 		}
 		data.mod_name = xstrdup(data.filename);
+		data.filepath = file->file->filename;
 		data.config_check_data = ccd;
 
 		char *suffix_ptr = strrchr(data.mod_name, '.');

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -256,7 +256,13 @@ FUNCTIONAL_TEST_FILES=functional/end-to-end.bats \
 			functional/policies/parse_errors/test8.te \
 			functional/policies/parse_errors/test8.output \
 			functional/policies/parse_errors/test9.te \
-			functional/policies/parse_errors/test9.output
+			functional/policies/parse_errors/test9.output \
+			functional/policies/report_format/test1.output \
+			functional/policies/report_format/test1.output.full \
+			functional/policies/report_format/test1.output.summary \
+			functional/policies/report_format/test1.output.summaryonly \
+			functional/policies/report_format/test1.output.warn \
+			functional/policies/report_format/test1.te
 
 EXTRA_DIST = ${AV_FILE_PERM_FILES} ${AV_SOCKET_PERM_FILES} ${AV_X_CURSOR_PERM_FILES} ${SAMPLE_CONFIG_FILES} ${SAMPLE_POLICY_FILES} ${FUNCTIONAL_TEST_FILES}
 

--- a/tests/check_if_checks.c
+++ b/tests/check_if_checks.c
@@ -111,7 +111,7 @@ START_TEST(test_check_type_used_but_not_required_in_if) {
 	free(av_data->sources->string);
 	av_data->sources->string = strdup("$1");
 
-	const struct check_data cdata = { NULL, NULL, FILE_IF_FILE, NULL };
+	const struct check_data cdata = { NULL, NULL, NULL, FILE_IF_FILE, NULL };
 
 	struct check_result *res = check_name_used_but_not_required_in_if(&cdata, cur);
 
@@ -170,7 +170,7 @@ START_TEST (test_check_type_required_but_not_used_in_if) {
 
 	cur = cur->prev->first_child->next; // the declaration
 
-	const struct check_data cdata = { NULL, NULL, FILE_IF_FILE, NULL };
+	const struct check_data cdata = { NULL, NULL, NULL, FILE_IF_FILE, NULL };
 
 	ck_assert_ptr_null(check_name_required_but_not_used_in_if(&cdata, cur));
 
@@ -230,7 +230,7 @@ START_TEST (test_system_r_exception) {
 	cur->data.ra_data->from = sl_from_str("system_r");
 	cur->data.ra_data->to = sl_from_str("staff_r");
 
-	const struct check_data cdata = { NULL, NULL, FILE_IF_FILE, NULL };
+	const struct check_data cdata = { NULL, NULL, NULL, FILE_IF_FILE, NULL };
 
 	ck_assert_ptr_null(check_name_used_but_not_required_in_if(&cdata, cur));
 

--- a/tests/functional/end-to-end.bats
+++ b/tests/functional/end-to-end.bats
@@ -122,6 +122,22 @@ test_parse_error_impl() {
 	fi
 }
 
+test_report_format_impl() {
+	local OPTIONS=$1
+	local SOURCE_FILENAME=$2
+	local OUTPUT_FILENAME=$3
+
+	run ${SELINT_PATH} ${OPTIONS} -c configs/default.conf ./policies/report_format/${SOURCE_FILENAME}
+	echo ${output}
+	[ "$status" -eq 0 ]
+	local EXPECTED_OUTPUT=$(cat ./policies/report_format/${OUTPUT_FILENAME})
+	echo ${EXPECTED_OUTPUT}
+	# compatibility for different bison versions and ignore NOTE output
+	local NORMALIZED_OUTPUT=$(grep -vE '^Note: ' <<< "${output/ \$end/ end of file}")
+	echo ${NORMALIZED_OUTPUT}
+	[ "${NORMALIZED_OUTPUT}" == "${EXPECTED_OUTPUT}" ]
+}
+
 @test "X-001" {
 	test_one_check "X-001" "x01.*"
 }
@@ -467,4 +483,12 @@ test_parse_error_impl() {
 		skip "BATS_TIME_EXPENSIVE not set"
 	fi
 	test_parse_error_run 1
+}
+
+@test "report format" {
+	test_report_format_impl '' test1.te test1.output
+	test_report_format_impl --full-path test1.te test1.output.full
+	test_report_format_impl --summary test1.te test1.output.summary
+	test_report_format_impl '--level W' test1.te test1.output.warn
+	test_report_format_impl --summary-only test1.te test1.output.summaryonly
 }

--- a/tests/functional/policies/parse_errors/test1.output
+++ b/tests/functional/policies/parse_errors/test1.output
@@ -1,7 +1,7 @@
-test1.te:             3: (F): syntax error, unexpected STRING, expecting COLON or SEMICOLON (F-001)
+./policies/parse_errors/test1.te:3: (F): syntax error, unexpected STRING, expecting COLON or SEMICOLON (F-001)
     3 | allow source target cls permission;
       |                     ^~~
-test1.te:             3: (F): Error: Invalid statement (F-001)
+./policies/parse_errors/test1.te:3: (F): Error: Invalid statement (F-001)
     3 | allow source target cls permission;
       | ^~~~~~~~~~~~~~~~~~~~~~~
 Error: Failed to parse files

--- a/tests/functional/policies/parse_errors/test2.output
+++ b/tests/functional/policies/parse_errors/test2.output
@@ -1,4 +1,4 @@
-test2.te:             2: (F): syntax error, unexpected ALLOW, expecting end of file (F-001)
+./policies/parse_errors/test2.te:2: (F): syntax error, unexpected ALLOW, expecting end of file (F-001)
     2 | allow allow;
       | ^~~~~
 Error: Failed to parse files

--- a/tests/functional/policies/parse_errors/test3.output
+++ b/tests/functional/policies/parse_errors/test3.output
@@ -1,4 +1,4 @@
-test3_tmp.if:         2: (F): Error: Unexpected te-file parsed (F-001)
+./policies/parse_errors/test3_tmp.if:2: (F): Error: Unexpected te-file parsed (F-001)
     2 |     policy_module(          test2,
       |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     3 |

--- a/tests/functional/policies/parse_errors/test4.output
+++ b/tests/functional/policies/parse_errors/test4.output
@@ -1,4 +1,4 @@
-test4.te:             1: (F): syntax error, unexpected STRING, expecting end of file (F-001)
+./policies/parse_errors/test4.te:1: (F): syntax error, unexpected STRING, expecting end of file (F-001)
     1 | allo!
 Warning: Line in question contains unprintable character at position 5: 0x01
 Error: Failed to parse files

--- a/tests/functional/policies/parse_errors/test5.output
+++ b/tests/functional/policies/parse_errors/test5.output
@@ -1,7 +1,7 @@
-test5_tmp.te:         7: (F): syntax error, unexpected STRING, expecting COLON or SEMICOLON (F-001)
+./policies/parse_errors/test5_tmp.te:7: (F): syntax error, unexpected STRING, expecting COLON or SEMICOLON (F-001)
     7 |   clas
       |   ^~~~
-test5_tmp.te:         4: (F): Error: Invalid statement (F-001)
+./policies/parse_errors/test5_tmp.te:4: (F): Error: Invalid statement (F-001)
     4 | allow
       | ^~~~~
     5 |     source

--- a/tests/functional/policies/parse_errors/test6.output
+++ b/tests/functional/policies/parse_errors/test6.output
@@ -1,4 +1,4 @@
-test6_tmp.if:         2: (F): Error: Unexpected te-file parsed (F-001)
+./policies/parse_errors/test6_tmp.if:2: (F): Error: Unexpected te-file parsed (F-001)
     2 |     policy_module(          test2,
       |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     3 |

--- a/tests/functional/policies/parse_errors/test7.output
+++ b/tests/functional/policies/parse_errors/test7.output
@@ -1,4 +1,4 @@
-test7.if:             1: (F): Error: Unexpected te-file parsed (F-001)
+./policies/parse_errors/test7.if:1: (F): Error: Unexpected te-file parsed (F-001)
     6 |  ...  [truncated]
     7 |   ,
       |   ^

--- a/tests/functional/policies/parse_errors/test8.output
+++ b/tests/functional/policies/parse_errors/test8.output
@@ -1,7 +1,7 @@
-test8.te:             3: (F): Incomplete AV rule (F-001)
+./policies/parse_errors/test8.te:3: (F): Incomplete AV rule (F-001)
     3 | dontaudit system_r auditadm_r;
       | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-test8.te:             3: (F): Error: Invalid statement (F-001)
+./policies/parse_errors/test8.te:3: (F): Error: Invalid statement (F-001)
     3 | dontaudit system_r auditadm_r;
       | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Error: Failed to parse files

--- a/tests/functional/policies/parse_errors/test9.output
+++ b/tests/functional/policies/parse_errors/test9.output
@@ -1,7 +1,7 @@
-test9.te:             4: (F): syntax error, unexpected end of file, expecting BACKTICK (F-001)
+./policies/parse_errors/test9.te:4: (F): syntax error, unexpected end of file, expecting BACKTICK (F-001)
     4 |
       | ^
-test9.te:             3: (F): Error: Invalid statement (F-001)
+./policies/parse_errors/test9.te:3: (F): Error: Invalid statement (F-001)
     3 | ifdef(
       | ^~~~~~
     4 |

--- a/tests/functional/policies/report_format/test1.output
+++ b/tests/functional/policies/report_format/test1.output
@@ -1,0 +1,5 @@
+test1.te:             1: (W): Module name tet1 does not match file name test1.te (W-009)
+test1.te:             5: (S): Require block used in te file (use an interface call instead) (S-001)
+test1.te:             9: (W): Allow rule with complement or wildcard permission (W-008)
+test1.te:            10: (S): Permission macro read_perms does not match class dir (S-009)
+test1.te:            10: (W): Allow rule with complement or wildcard permission (W-008)

--- a/tests/functional/policies/report_format/test1.output.full
+++ b/tests/functional/policies/report_format/test1.output.full
@@ -1,0 +1,5 @@
+./policies/report_format/test1.te:1: (W): Module name tet1 does not match file name test1.te (W-009)
+./policies/report_format/test1.te:5: (S): Require block used in te file (use an interface call instead) (S-001)
+./policies/report_format/test1.te:9: (W): Allow rule with complement or wildcard permission (W-008)
+./policies/report_format/test1.te:10: (S): Permission macro read_perms does not match class dir (S-009)
+./policies/report_format/test1.te:10: (W): Allow rule with complement or wildcard permission (W-008)

--- a/tests/functional/policies/report_format/test1.output.summary
+++ b/tests/functional/policies/report_format/test1.output.summary
@@ -1,0 +1,10 @@
+test1.te:             1: (W): Module name tet1 does not match file name test1.te (W-009)
+test1.te:             5: (S): Require block used in te file (use an interface call instead) (S-001)
+test1.te:             9: (W): Allow rule with complement or wildcard permission (W-008)
+test1.te:            10: (S): Permission macro read_perms does not match class dir (S-009)
+test1.te:            10: (W): Allow rule with complement or wildcard permission (W-008)
+Found the following issue counts:
+S-001: 1
+S-009: 1
+W-008: 2
+W-009: 1

--- a/tests/functional/policies/report_format/test1.output.summaryonly
+++ b/tests/functional/policies/report_format/test1.output.summaryonly
@@ -1,0 +1,5 @@
+Found the following issue counts:
+S-001: 1
+S-009: 1
+W-008: 2
+W-009: 1

--- a/tests/functional/policies/report_format/test1.output.warn
+++ b/tests/functional/policies/report_format/test1.output.warn
@@ -1,0 +1,3 @@
+test1.te:             1: (W): Module name tet1 does not match file name test1.te (W-009)
+test1.te:             9: (W): Allow rule with complement or wildcard permission (W-008)
+test1.te:            10: (W): Allow rule with complement or wildcard permission (W-008)

--- a/tests/functional/policies/report_format/test1.te
+++ b/tests/functional/policies/report_format/test1.te
@@ -1,0 +1,10 @@
+policy_module(tet1, 0.0.1)
+
+type test1_t;
+
+gen_require(`
+	type test2_t;
+')
+
+allow test2_t test3_t:file *;
+allow test4_t test4_t:dir ~read_perms;


### PR DESCRIPTION
* Display full path on parser errors
  Parser error are severe and also quite rare.  Print the full path by default.

* Add option to print full paths
  Add command line option '--full-path' to print the full path for issues.

Closes: #232