### PR TITLE
Check memory allocations

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 bin_PROGRAMS = selint
-selint_SOURCES = main.c lex.l parse.y tree.c tree.h selint_error.h parse_functions.c parse_functions.h maps.c maps.h runner.c runner.h parse_fc.c parse_fc.h template.c template.h file_list.c file_list.h check_hooks.c check_hooks.h fc_checks.c fc_checks.h util.c util.h if_checks.c if_checks.h selint_config.c selint_config.h string_list.c string_list.h startup.c startup.h te_checks.c te_checks.h ordering.c ordering.h color.c color.h perm_macro.c perm_macro.h
+selint_SOURCES = main.c lex.l parse.y tree.c tree.h selint_error.h parse_functions.c parse_functions.h maps.c maps.h runner.c runner.h parse_fc.c parse_fc.h template.c template.h file_list.c file_list.h check_hooks.c check_hooks.h fc_checks.c fc_checks.h util.c util.h if_checks.c if_checks.h selint_config.c selint_config.h string_list.c string_list.h startup.c startup.h te_checks.c te_checks.h ordering.c ordering.h color.c color.h perm_macro.c perm_macro.h xalloc.h
 BUILT_SOURCES = parse.h
 AM_YFLAGS = -d -Wno-yacc -Werror=conflicts-rr -Werror=conflicts-sr
 

--- a/src/check_hooks.c
+++ b/src/check_hooks.c
@@ -22,6 +22,7 @@
 
 #include "check_hooks.h"
 #include "color.h"
+#include "xalloc.h"
 
 int found_issue = 0;
 int suppress_output = 0;
@@ -29,11 +30,11 @@ int suppress_output = 0;
 #define ALLOC_NODE(nl)  if (ck->check_nodes[nl]) { \
 		loc = ck->check_nodes[nl]; \
 		while (loc->next) { loc = loc->next; } \
-		loc->next = malloc(sizeof(struct check_node)); \
+		loc->next = xmalloc(sizeof(struct check_node)); \
 		if (!loc->next) { return SELINT_OUT_OF_MEM; } \
 		loc = loc->next; \
 } else { \
-		ck->check_nodes[nl] = malloc(sizeof(struct check_node)); \
+		ck->check_nodes[nl] = xmalloc(sizeof(struct check_node)); \
 		if (!ck->check_nodes[nl]) { return SELINT_OUT_OF_MEM; } \
 		loc = ck->check_nodes[nl]; \
 }
@@ -48,7 +49,7 @@ enum selint_error add_check(enum node_flavor check_flavor, struct checks *ck,
 	ALLOC_NODE(check_flavor);
 
 	loc->check_function = check_function;
-	loc->check_id = strdup(check_id);
+	loc->check_id = xstrdup(check_id);
 	loc->issues_found = 0;
 	loc->next = NULL;
 
@@ -236,7 +237,7 @@ void display_check_issue_counts(const struct checks *ck)
 	unsigned int printed_something = 0;
 
 	// Build flat array of check nodes
-	struct check_node **node_arr = calloc(num_nodes, sizeof(struct check_node *));
+	struct check_node **node_arr = xcalloc(num_nodes, sizeof(struct check_node *));
 	unsigned int node_arr_index = 0;
 	for (int i=0; i <= NODE_ERROR; i++) {
 		if (ck->check_nodes[i]) {
@@ -295,7 +296,7 @@ struct check_result *make_check_result(char severity, unsigned int check_id,
                                        const char *format, ...)
 {
 
-	struct check_result *res = malloc(sizeof(struct check_result));
+	struct check_result *res = xmalloc(sizeof(struct check_result));
 
 	res->severity = severity;
 	res->check_id = check_id;
@@ -306,7 +307,7 @@ struct check_result *make_check_result(char severity, unsigned int check_id,
 	if (vasprintf(&res->message, format, args) == -1) {
 		res->severity = 'F';
 		res->check_id = F_ID_INTERNAL;
-		res->message = strdup("Failed to generate check result message");
+		res->message = xstrdup("Failed to generate check result message");
 	}
 
 	va_end(args);

--- a/src/file_list.c
+++ b/src/file_list.c
@@ -18,17 +18,18 @@
 #include <stdlib.h>
 
 #include "file_list.h"
+#include "xalloc.h"
 
 void file_list_push_back(struct policy_file_list *list,
                          struct policy_file *file)
 {
 
 	if (list->tail) {
-		list->tail->next = malloc(sizeof(struct policy_file_node));
+		list->tail->next = xmalloc(sizeof(struct policy_file_node));
 		list->tail = list->tail->next;
 	} else {
 		list->head = list->tail =
-			malloc(sizeof(struct policy_file_node));
+			xmalloc(sizeof(struct policy_file_node));
 	}
 	list->tail->file = file;
 	list->tail->next = NULL;
@@ -36,9 +37,9 @@ void file_list_push_back(struct policy_file_list *list,
 
 struct policy_file *make_policy_file(const char *filename, struct policy_node *ast)
 {
-	struct policy_file *ret = malloc(sizeof(struct policy_file));
+	struct policy_file *ret = xmalloc(sizeof(struct policy_file));
 
-	ret->filename = strdup(filename);
+	ret->filename = xstrdup(filename);
 	ret->ast = ast;
 	return ret;
 }

--- a/src/lex.l
+++ b/src/lex.l
@@ -18,6 +18,7 @@
 #include <string.h>
 #include "tree.h"
 #include "parse.h"
+#include "xalloc.h"
 
 
 extern void reset_current_lines(void);
@@ -92,6 +93,7 @@ void reset_current_lines(void) {
 %option reentrant
 %option bison-bridge
 %option bison-locations
+%option noyyalloc noyyfree noyyrealloc
 %%
 policy_module { return POLICY_MODULE; }
 module { return MODULE; }
@@ -149,13 +151,13 @@ typebounds { return TYPEBOUNDS; }
 interface { return INTERFACE; }
 template { return TEMPLATE; }
 userdebug_or_eng { return USERDEBUG_OR_ENG; }
-[0-9]+\.[0-9]+(\.[0-9]+)? { yylval->string = strdup(yytext); return VERSION_NO; }
-[0-9]+ { yylval->string = strdup(yytext); return NUMBER; }
-[a-zA-Z\$\/][a-zA-Z0-9_\$\*\/\-]* { yylval->string = strdup(yytext); return STRING; }
-[0-9a-zA-Z\$\/][a-zA-Z0-9_\$\*\/\-]* { yylval->string = strdup(yytext); return NUM_STRING; }
-[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3} { yylval->string = strdup(yytext); return IPV4; }
-([0-9A-Fa-f]{1,4})?\:([0-9A-Fa-f\:])*\:([0-9A-Fa-f]{1,4})?(\:[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})? { yylval->string = strdup(yytext); return IPV6; }
-\"[a-zA-Z0-9_\.\-\:~\$\[\]]*\" { yylval->string = strdup(yytext); return QUOTED_STRING; }
+[0-9]+\.[0-9]+(\.[0-9]+)? { yylval->string = xstrdup(yytext); return VERSION_NO; }
+[0-9]+ { yylval->string = xstrdup(yytext); return NUMBER; }
+[a-zA-Z\$\/][a-zA-Z0-9_\$\*\/\-]* { yylval->string = xstrdup(yytext); return STRING; }
+[0-9a-zA-Z\$\/][a-zA-Z0-9_\$\*\/\-]* { yylval->string = xstrdup(yytext); return NUM_STRING; }
+[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3} { yylval->string = xstrdup(yytext); return IPV4; }
+([0-9A-Fa-f]{1,4})?\:([0-9A-Fa-f\:])*\:([0-9A-Fa-f]{1,4})?(\:[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})? { yylval->string = xstrdup(yytext); return IPV6; }
+\"[a-zA-Z0-9_\.\-\:~\$\[\]]*\" { yylval->string = xstrdup(yytext); return QUOTED_STRING; }
 \-[\-ldbcsp][ \t] { return FILE_TYPE_SPECIFIER; }
 \( { return OPEN_PAREN; }
 \) { return CLOSE_PAREN; }
@@ -176,8 +178,19 @@ userdebug_or_eng { return USERDEBUG_OR_ENG; }
 \!\= { return NOT_EQUAL; }
 \! { return NOT; }
 \=\= { return EQUAL; }
-\#selint\-disable\:\ ?[CSWEF]\-[0-9]+(\,\ ?[CSWEF]\-[0-9]+)*$ { yylval->string = strdup(yytext); return SELINT_COMMAND; }
+\#selint\-disable\:\ ?[CSWEF]\-[0-9]+(\,\ ?[CSWEF]\-[0-9]+)*$ { yylval->string = xstrdup(yytext); return SELINT_COMMAND; }
 \#.*$ { return COMMENT; }
 dnl(.*)?$ ; /* skip m4 comment lines */
 [ \t\n\r] ; /* normally skip whitespace */
 . { yylval->symbol = *yytext; return UNKNOWN_TOKEN; }
+%%
+
+void *yyalloc(size_t bytes, __attribute__((unused)) void *yyscanner) {
+	return xmalloc(bytes);
+}
+void *yyrealloc(void *ptr, size_t bytes, __attribute__((unused)) void *yyscanner) {
+	return xrealloc(ptr, bytes);
+}
+void yyfree(void *ptr, __attribute__((unused)) void *yyscanner) {
+	return free(ptr);
+}

--- a/src/main.c
+++ b/src/main.c
@@ -30,6 +30,7 @@
 #include "selint_config.h"
 #include "startup.h"
 #include "color.h"
+#include "xalloc.h"
 
 // ASCII characters go up to 127
 #define CONTEXT_ID          128
@@ -195,28 +196,28 @@ int main(int argc, char **argv)
 			// Disable a given check
 			if (cl_d_cursor) {
 				cl_d_cursor->next =
-					calloc(1, sizeof(struct string_list));
+					xcalloc(1, sizeof(struct string_list));
 				cl_d_cursor = cl_d_cursor->next;
 			} else {
 				cl_d_cursor =
-					calloc(1, sizeof(struct string_list));
+					xcalloc(1, sizeof(struct string_list));
 				cl_disabled_checks = cl_d_cursor;
 			}
-			cl_d_cursor->string = strdup(optarg);
+			cl_d_cursor->string = xstrdup(optarg);
 			break;
 
 		case 'e':
 			// Enable a given check
 			if (cl_e_cursor) {
 				cl_e_cursor->next =
-					calloc(1, sizeof(struct string_list));
+					xcalloc(1, sizeof(struct string_list));
 				cl_e_cursor = cl_e_cursor->next;
 			} else {
 				cl_e_cursor =
-					calloc(1, sizeof(struct string_list));
+					xcalloc(1, sizeof(struct string_list));
 				cl_enabled_checks = cl_e_cursor;
 			}
-			cl_e_cursor->string = strdup(optarg);
+			cl_e_cursor->string = xstrdup(optarg);
 			break;
 
 		case 'E':
@@ -370,21 +371,21 @@ int main(int argc, char **argv)
 	}
 
 	struct policy_file_list *te_files =
-		calloc(1, sizeof(struct policy_file_list));
+		xcalloc(1, sizeof(struct policy_file_list));
 
 	struct policy_file_list *if_files =
-		calloc(1, sizeof(struct policy_file_list));
+		xcalloc(1, sizeof(struct policy_file_list));
 
 	struct policy_file_list *fc_files =
-		calloc(1, sizeof(struct policy_file_list));
+		xcalloc(1, sizeof(struct policy_file_list));
 
 	struct policy_file_list *context_te_files =
-		calloc(1, sizeof(struct policy_file_list));
+		xcalloc(1, sizeof(struct policy_file_list));
 
 	struct policy_file_list *context_if_files =
-		calloc(1, sizeof(struct policy_file_list));
+		xcalloc(1, sizeof(struct policy_file_list));
 
-	char **paths = malloc(sizeof(char *) * (unsigned)argc - (unsigned)optind + 2);
+	char **paths = xmalloc(sizeof(char *) * (unsigned)argc - (unsigned)optind + 2);
 
 	int i = 0;
 	while (optind < argc) {
@@ -414,7 +415,7 @@ int main(int argc, char **argv)
 			file_list_push_back(if_files,
 			                    make_policy_file(file->fts_path,
 			                                     NULL));
-			char *mod_name = strdup(file->fts_name);
+			char *mod_name = xstrdup(file->fts_name);
 			mod_name[file->fts_namelen - 3] = '\0';
 			insert_into_mod_layers_map(mod_name, file->fts_parent->fts_name);
 			free(mod_name);
@@ -425,15 +426,15 @@ int main(int argc, char **argv)
 		} else if (source_flag
 		           && !strcmp(file->fts_name, "modules.conf")) {
 			// TODO: Make modules.conf name configurable
-			modules_conf_path = strdup(file->fts_path);
+			modules_conf_path = xstrdup(file->fts_path);
 		} else if (source_flag
 		           && !strcmp(file->fts_name, "obj_perm_sets.spt")) {
 			// TODO: Make obj_perm_sets.spt name configurable
-			obj_perm_sets_path = strdup(file->fts_path);
+			obj_perm_sets_path = xstrdup(file->fts_path);
 		} else if (source_flag
 		           && !strcmp(file->fts_name, "access_vectors")) {
 			// TODO: Make access_vectors name configurable
-			access_vector_path = strdup(file->fts_path);
+			access_vector_path = xstrdup(file->fts_path);
 		} else if (source_flag
 		           && (!strcmp(file->fts_name, "global_booleans") || !strcmp(file->fts_name, "global_tunables"))) {
 			// TODO: Make names configurable
@@ -496,15 +497,15 @@ int main(int argc, char **argv)
 			} else if (source_flag
                                    && !modules_conf_path
                                    && 0 == strcmp(file->fts_name, "modules.conf")) {
-				modules_conf_path = strdup(file->fts_path);
+				modules_conf_path = xstrdup(file->fts_path);
 			} else if (source_flag
                                    && !obj_perm_sets_path
                                    && 0 == strcmp(file->fts_name, "obj_perm_sets.spt")) {
-				obj_perm_sets_path = strdup(file->fts_path);
+				obj_perm_sets_path = xstrdup(file->fts_path);
 			} else if (source_flag
                                    && !access_vector_path
                                    && 0 == strcmp(file->fts_name, "access_vectors")) {
-				access_vector_path = strdup(file->fts_path);
+				access_vector_path = xstrdup(file->fts_path);
 			} else if (source_flag
 			           && !str_in_sl(file->fts_path, global_cond_files)
 			           && (0 == strcmp(file->fts_name, "global_booleans") || 0 == strcmp(file->fts_name, "global_tunables"))) {

--- a/src/maps.c
+++ b/src/maps.c
@@ -15,6 +15,7 @@
 */
 
 #include "maps.h"
+#include "xalloc.h"
 
 #if defined(__clang__) && defined(__clang_major__) && (__clang_major__ >= 4)
 #if (__clang_major__ >= 12)
@@ -91,9 +92,9 @@ void insert_into_decl_map(const char *name, const char *module_name,
 
 	if (decl == NULL) {     // Item not in hash table already
 
-		decl = malloc(sizeof(struct hash_elem));
-		decl->key = strdup(name);
-		decl->val = strdup(module_name);
+		decl = xmalloc(sizeof(struct hash_elem));
+		decl->key = xstrdup(name);
+		decl->val = xstrdup(module_name);
 
 		switch (flavor) {
 		case DECL_TYPE:
@@ -158,9 +159,9 @@ void insert_into_mods_map(const char *mod_name, const char *status)
 	HASH_FIND(hh_mods, mods_map, mod_name, strlen(mod_name), mod);
 
 	if (!mod) {
-		mod = malloc(sizeof(struct hash_elem));
-		mod->key = strdup(mod_name);
-		mod->val = strdup(status);
+		mod = xmalloc(sizeof(struct hash_elem));
+		mod->key = xstrdup(mod_name);
+		mod->val = xstrdup(status);
 		HASH_ADD_KEYPTR(hh_mods, mods_map, mod->key, strlen(mod->key),
 		                mod);
 	}
@@ -189,9 +190,9 @@ void insert_into_mod_layers_map(const char *mod_name, const char *layer)
 	HASH_FIND(hh_mod_layers, mod_layers_map, mod_name, strlen(mod_name), mod);
 
 	if (!mod) {
-		mod = malloc(sizeof(struct hash_elem));
-		mod->key = strdup(mod_name);
-		mod->val = strdup(layer);
+		mod = xmalloc(sizeof(struct hash_elem));
+		mod->key = xstrdup(mod_name);
+		mod->val = xstrdup(layer);
 		HASH_ADD_KEYPTR(hh_mod_layers, mod_layers_map, mod->key, strlen(mod->key),
 		                mod);
 	}
@@ -221,15 +222,15 @@ void insert_into_ifs_map(const char *if_name, const char *mod_name)
 	HASH_FIND(hh_interfaces, interfaces_map, if_name, strlen(if_name), if_call);
 
 	if (!if_call) {
-		if_call = malloc(sizeof(struct if_hash_elem));
-		if_call->name = strdup(if_name);
-		if_call->module = strdup(mod_name);
+		if_call = xmalloc(sizeof(struct if_hash_elem));
+		if_call->name = xstrdup(if_name);
+		if_call->module = xstrdup(mod_name);
 		if_call->flags = 0;
 		HASH_ADD_KEYPTR(hh_interfaces, interfaces_map, if_call->name,
 				strlen(if_call->name), if_call);
 	} else {
 		free(if_call->module);
-		if_call->module = strdup(mod_name);
+		if_call->module = xstrdup(mod_name);
 	}
 }
 
@@ -280,8 +281,8 @@ void mark_transform_if(const char *if_name)
 	HASH_FIND(hh_interfaces, interfaces_map, if_name, strlen(if_name), transform_if);
 
 	if (!transform_if) {
-		transform_if = malloc(sizeof(struct if_hash_elem));
-		transform_if->name = strdup(if_name);
+		transform_if = xmalloc(sizeof(struct if_hash_elem));
+		transform_if->name = xstrdup(if_name);
 		transform_if->module = NULL;
 		transform_if->flags = TRANSFORM_IF;
 		HASH_ADD_KEYPTR(hh_interfaces, interfaces_map, transform_if->name,
@@ -311,8 +312,8 @@ void mark_filetrans_if(const char *if_name)
 	HASH_FIND(hh_interfaces, interfaces_map, if_name, strlen(if_name), filetrans_if);
 
 	if (!filetrans_if) {
-		filetrans_if = malloc(sizeof(struct if_hash_elem));
-		filetrans_if->name = strdup(if_name);
+		filetrans_if = xmalloc(sizeof(struct if_hash_elem));
+		filetrans_if->name = xstrdup(if_name);
 		filetrans_if->module = NULL;
 		filetrans_if->flags = FILETRANS_IF;
 		HASH_ADD_KEYPTR(hh_interfaces, interfaces_map, filetrans_if->name,
@@ -342,8 +343,8 @@ void mark_role_if(const char *if_name)
 	HASH_FIND(hh_interfaces, interfaces_map, if_name, strlen(if_name), role_if);
 
 	if (!role_if) {
-		role_if = malloc(sizeof(struct if_hash_elem));
-		role_if->name = strdup(if_name);
+		role_if = xmalloc(sizeof(struct if_hash_elem));
+		role_if->name = xstrdup(if_name);
 		role_if->module = NULL;
 		role_if->flags = ROLE_IF;
 		HASH_ADD_KEYPTR(hh_interfaces, interfaces_map, role_if->name,
@@ -378,8 +379,8 @@ void mark_used_if(const char *if_name)
 	HASH_FIND(hh_interfaces, interfaces_map, if_name, strlen(if_name), used_if);
 
 	if (!used_if) {
-		used_if = malloc(sizeof(struct if_hash_elem));
-		used_if->name = strdup(if_name);
+		used_if = xmalloc(sizeof(struct if_hash_elem));
+		used_if->name = xstrdup(if_name);
 		used_if->module = NULL;
 		used_if->flags = USED_IF;
 		HASH_ADD_KEYPTR(hh_interfaces, interfaces_map, used_if->name,
@@ -449,8 +450,8 @@ static void insert_into_template_map(const char *name, void *new_node,
 	HASH_FIND(hh, template_map, name, strlen(name), template);
 
 	if (template == NULL) {
-		template = malloc(sizeof(struct template_hash_elem));
-		template->name = strdup(name);
+		template = xmalloc(sizeof(struct template_hash_elem));
+		template->name = xstrdup(name);
 		template->declarations = NULL;
 		template->calls = NULL;
 
@@ -472,13 +473,13 @@ void insert_decl_into_template_map(const char *name, enum decl_flavor flavor,
 {
 
 	struct declaration_data *new_data =
-		malloc(sizeof(struct declaration_data));
+		xmalloc(sizeof(struct declaration_data));
 
 	new_data->flavor = flavor;
-	new_data->name = strdup(declaration);
+	new_data->name = xstrdup(declaration);
 	new_data->attrs = NULL; //Not needed
 
-	struct decl_list *new_node = malloc(sizeof(struct decl_list));
+	struct decl_list *new_node = xmalloc(sizeof(struct decl_list));
 	new_node->decl = new_data;
 	new_node->next = NULL;
 
@@ -488,7 +489,7 @@ void insert_decl_into_template_map(const char *name, enum decl_flavor flavor,
 void insert_call_into_template_map(const char *name, struct if_call_data *call)
 {
 
-	struct if_call_list *new_node = malloc(sizeof(struct if_call_list));
+	struct if_call_list *new_node = xmalloc(sizeof(struct if_call_list));
 
 	new_node->call = call;
 	new_node->next = NULL;
@@ -538,8 +539,8 @@ void insert_into_permmacros_map(const char *name, struct string_list *permission
 	HASH_FIND(hh_permmacros, permmacros_map, name, strlen(name), perm_macro);
 
 	if (!perm_macro) {
-		perm_macro = malloc(sizeof(struct sl_hash_elem));
-		perm_macro->key = strdup(name);
+		perm_macro = xmalloc(sizeof(struct sl_hash_elem));
+		perm_macro->key = xstrdup(name);
 		perm_macro->val = permissions;
 		HASH_ADD_KEYPTR(hh_permmacros, permmacros_map, perm_macro->key, strlen(perm_macro->key),
 		                perm_macro);

--- a/src/ordering.c
+++ b/src/ordering.c
@@ -22,6 +22,7 @@
 
 #include "ordering.h"
 #include "maps.h"
+#include "xalloc.h"
 
 #define SECTION_NON_ORDERED "_non_ordered"
 #define SECTION_DECLARATION "_declaration"
@@ -46,7 +47,7 @@ struct ordering_metadata *prepare_ordering_metadata(const struct check_data *dat
 {
 	const struct policy_node *cur = head->next; // head is file.  Order the contents
 	size_t count = 0;
-	struct section_data *sections = calloc(1, sizeof(struct section_data));
+	struct section_data *sections = xcalloc(1, sizeof(struct section_data));
 
 	while (cur) {
 		if (add_section_info(sections, get_section(cur), cur->lineno) == SELINT_BAD_ARG) {
@@ -58,7 +59,7 @@ struct ordering_metadata *prepare_ordering_metadata(const struct check_data *dat
 	}
 	calculate_average_lines(sections);
 
-	struct ordering_metadata *ret = calloc(1, sizeof(struct ordering_metadata) +
+	struct ordering_metadata *ret = xcalloc(1, sizeof(struct ordering_metadata) +
 	                                       (count * sizeof(struct order_node)));
 	ret->mod_name = data->mod_name; // Will only be needed for duration of check, so will remain allocated
 	                                // until we are done with this copy
@@ -163,7 +164,7 @@ enum selint_error add_section_info(struct section_data *sections,
 	if (sections->section_name != NULL) {
 		while (0 != strcmp(cur->section_name, section_name)) {
 			if (cur->next == NULL) {
-				cur->next = calloc(1, sizeof(struct section_data));
+				cur->next = xcalloc(1, sizeof(struct section_data));
 				cur = cur->next;
 				break;
 			}
@@ -173,7 +174,7 @@ enum selint_error add_section_info(struct section_data *sections,
 	// cur is now the appropriate section_data node.  If section_name is
 	// NULL, then this is a new node
 	if (!cur->section_name) {
-		cur->section_name = strdup(section_name);
+		cur->section_name = xstrdup(section_name);
 	}
 
 	cur->lineno_count++;
@@ -932,13 +933,13 @@ char *get_ordering_reason(const struct ordering_metadata *order_data, unsigned i
 		if (other_lss == LSS_KERNEL || other_lss == LSS_SYSTEM || other_lss == LSS_OTHER) {
 			enum local_subsection this_lss = get_local_subsection(order_data->mod_name, this_node, variant);
 			if (this_lss == LSS_KERNEL) {
-				followup_str = strdup("  (This interface is in the kernel layer.)");
+				followup_str = xstrdup("  (This interface is in the kernel layer.)");
 			} else if (this_lss == LSS_SYSTEM) {
-				followup_str = strdup("  (This interface is in the system layer.)");
+				followup_str = xstrdup("  (This interface is in the system layer.)");
 			} else if (this_lss == LSS_OTHER) {
-				followup_str = strdup("  (This interface is in a layer other than kernel or system.)");
+				followup_str = xstrdup("  (This interface is in a layer other than kernel or system.)");
 			} else if (this_lss == LSS_KERNEL_MOD) {
-				followup_str = strdup("  (This interface is in the kernel module.)");
+				followup_str = xstrdup("  (This interface is in the kernel module.)");
 			}
 			// Otherwise, it's not an interface call and is hopefully obvious to the user what layer its in
 		}
@@ -969,7 +970,7 @@ char *get_ordering_reason(const struct ordering_metadata *order_data, unsigned i
 		str_len += strlen(followup_str);
 	}
 
-	char *ret = malloc(sizeof(char) * str_len);
+	char *ret = xmalloc(sizeof(char) * str_len);
 
 	ssize_t written = snprintf(ret, str_len,
 	                           "Line out of order.  It is of type %s %s line %u %s.",

--- a/src/parse.y
+++ b/src/parse.y
@@ -34,8 +34,11 @@
 	#include "check_hooks.h"
 	#include "util.h"
 	#include "color.h"
+	#include "xalloc.h"
 
 	#define YYDEBUG 1
+	#define YYMALLOC xmalloc
+	#define YYREALLOC xrealloc
 
 	struct location
 	{
@@ -477,7 +480,7 @@ strings:
 sl_item:
 	STRING
 	|
-	DASH STRING { $$ = malloc(sizeof(char) * (strlen($2) + 2));
+	DASH STRING { $$ = xmalloc(sizeof(char) * (strlen($2) + 2));
 			$$[0] = '-';
 			$$[1] = '\0';
 			strcat($$, $2);
@@ -738,7 +741,7 @@ arg_list_items:
 	;
 
 arg_list_item:
-	DASH arg_list_item { $$ = malloc(sizeof(char) * (strlen($2) + 2));
+	DASH arg_list_item { $$ = xmalloc(sizeof(char) * (strlen($2) + 2));
 			$$[0] = '-';
 			$$[1] = '\0';
 			strcat($$, $2);
@@ -766,7 +769,7 @@ args:
 	|
 	args COMMA arg { $3->arg_start = 1; $$ = concat_string_lists($1, $3); }
 	|
-	args sl_item { struct string_list *sl = calloc(1, sizeof(struct string_list));
+	args sl_item { struct string_list *sl = xcalloc(1, sizeof(struct string_list));
 			sl->string = $2;
 			sl->has_incorrect_space = 1;
 			$1->arg_start = 1;
@@ -775,7 +778,7 @@ args:
 
 mls_range:
 	mls_level DASH mls_level { size_t len = strlen($1) + strlen($3) + 1 /* DASH */ + 1 /* NT */;
-				$$ = malloc(len);
+				$$ = xmalloc(len);
 				snprintf($$, len, "%s-%s", $1, $3);
 				free($1); free($3); }
 	|
@@ -786,7 +789,7 @@ mls_level:
 	mls_component
 	|
 	mls_component COLON mls_component { size_t len = strlen($1) + strlen($3) + 1 /* COLON */ + 1 /* NT */;
-				$$ = malloc(len);
+				$$ = xmalloc(len);
 				snprintf($$, len, "%s:%s", $1, $3);
 				free($1); free($3); }
 	;
@@ -795,7 +798,7 @@ mls_component:
 	STRING
 	|
 	STRING PERIOD STRING { size_t len = strlen($1) + strlen($3) + 1 /* PERIOD */ + 1 /* NT */;
-				$$ = malloc(len);
+				$$ = xmalloc(len);
 				snprintf($$, len, "%s.%s", $1, $3);
 				free($1); free($3); }
 	;
@@ -905,7 +908,7 @@ define_expansion:
 maybe_string_comma:
 	STRING COMMA
 	|
-	COMMA { $$ = strdup(""); }
+	COMMA { $$ = xstrdup(""); }
 	;
 
 gen_user:
@@ -1153,7 +1156,7 @@ static void yyerror(const YYLTYPE *locp, __attribute__((unused)) yyscan_t scanne
 
 		struct check_data data;
 		data.mod_name = get_current_module_name();
-		char *copy = strdup(parsing_filename);
+		char *copy = xstrdup(parsing_filename);
 		data.filename = basename(copy);
 		data.flavor = FILE_TE_FILE; // We don't know but it's unused by display_check_result
 
@@ -1236,7 +1239,7 @@ static void yyerror(const YYLTYPE *locp, __attribute__((unused)) yyscan_t scanne
 }
 
 struct policy_node *yyparse_wrapper(FILE *filefd, const char *filename, enum node_flavor expected_flavor) {
-	struct policy_node *ast = calloc(1, sizeof(struct policy_node));
+	struct policy_node *ast = xcalloc(1, sizeof(struct policy_node));
 	ast->flavor = expected_node_flavor = expected_flavor;
 	yyscan_t scanner;
 	yylex_init(&scanner);

--- a/src/parse_fc.c
+++ b/src/parse_fc.c
@@ -20,6 +20,7 @@
 
 #include "parse_fc.h"
 #include "tree.h"
+#include "xalloc.h"
 
 // "gen_context("
 #define GEN_CONTEXT_LEN 12
@@ -28,11 +29,11 @@ struct fc_entry *parse_fc_line(char *line)
 {
 	const char *whitespace = " \t";
 
-	struct fc_entry *out = malloc(sizeof(struct fc_entry));
+	struct fc_entry *out = xmalloc(sizeof(struct fc_entry));
 
 	memset(out, 0, sizeof(struct fc_entry));
 
-	char *orig_line = strdup(line); // If the object class is omitted, we need to revert
+	char *orig_line = xstrdup(line); // If the object class is omitted, we need to revert
 
 	char *pos = strtok(line, whitespace);
 
@@ -40,7 +41,7 @@ struct fc_entry *parse_fc_line(char *line)
 		goto cleanup;
 	}
 
-	out->path = strdup(pos);
+	out->path = xstrdup(pos);
 
 	pos = strtok(NULL, whitespace);
 
@@ -125,12 +126,12 @@ struct fc_entry *parse_fc_line(char *line)
 		out->context->has_gen_context = 1;
 		if (maybe_c) {
 			out->context->range =
-				malloc(strlen(maybe_s) + 1 + strlen(maybe_c) + 1);
+				xmalloc(strlen(maybe_s) + 1 + strlen(maybe_c) + 1);
 			strcpy(out->context->range, maybe_s);
 			strcat(out->context->range, ":");
 			strcat(out->context->range, maybe_c);
 		} else if (maybe_s) {
-			out->context->range = strdup(maybe_s);
+			out->context->range = xstrdup(maybe_s);
 		} else {
 			out->context->range = NULL;
 		}
@@ -162,7 +163,7 @@ struct sel_context *parse_context(char *context_str)
 		return NULL;
 	}
 
-	struct sel_context *context = malloc(sizeof(struct sel_context));
+	struct sel_context *context = xmalloc(sizeof(struct sel_context));
 	memset(context, 0, sizeof(struct sel_context));
 	// User
 	char *pos = strtok(context_str, ":");
@@ -171,7 +172,7 @@ struct sel_context *parse_context(char *context_str)
 		goto cleanup;
 	}
 
-	context->user = strdup(pos);
+	context->user = xstrdup(pos);
 
 	// Role
 	pos = strtok(NULL, ":");
@@ -180,7 +181,7 @@ struct sel_context *parse_context(char *context_str)
 		goto cleanup;
 	}
 
-	context->role = strdup(pos);
+	context->role = xstrdup(pos);
 
 	// Type
 	pos = strtok(NULL, ":");
@@ -189,12 +190,12 @@ struct sel_context *parse_context(char *context_str)
 		goto cleanup;
 	}
 
-	context->type = strdup(pos);
+	context->type = xstrdup(pos);
 
 	pos = strtok(NULL, ":");
 
 	if (pos) {
-		context->range = strdup(pos);
+		context->range = xstrdup(pos);
 		if (strtok(NULL, ":")) {
 			goto cleanup;
 		}
@@ -236,7 +237,7 @@ struct policy_node *parse_fc_file(const char *filename, const struct string_list
 		return NULL;
 	}
 
-	struct policy_node *head = malloc(sizeof(struct policy_node));
+	struct policy_node *head = xmalloc(sizeof(struct policy_node));
 	memset(head, 0, sizeof(struct policy_node));
 	head->flavor = NODE_FC_FILE;
 

--- a/src/parse_functions.c
+++ b/src/parse_functions.c
@@ -23,13 +23,14 @@
 #include "template.h"
 #include "util.h"
 #include "perm_macro.h"
+#include "xalloc.h"
 
 char *module_name = NULL;
 
 enum selint_error insert_header(struct policy_node **cur, const char *mn,
                                 enum header_flavor flavor, unsigned int lineno)
 {
-	struct header_data *data = (struct header_data *)malloc(sizeof(struct header_data));
+	struct header_data *data = (struct header_data *)xmalloc(sizeof(struct header_data));
 	if (!data) {
 		return SELINT_OUT_OF_MEM;
 	}
@@ -37,7 +38,7 @@ enum selint_error insert_header(struct policy_node **cur, const char *mn,
 	memset(data, 0, sizeof(struct header_data));
 
 	data->flavor = flavor;
-	data->module_name = strdup(mn);
+	data->module_name = xstrdup(mn);
 	if (!data->module_name) {
 		free(data);
 		return SELINT_OUT_OF_MEM;
@@ -60,7 +61,7 @@ void set_current_module_name(const char *mn)
 	if (module_name != NULL) {
 		free(module_name);
 	}
-	module_name = strdup(mn);
+	module_name = xstrdup(mn);
 }
 
 char *get_current_module_name()
@@ -114,7 +115,7 @@ enum selint_error insert_declaration(struct policy_node **cur,
 		}
 	}
 
-	struct declaration_data *data = (struct declaration_data *)malloc(sizeof(struct declaration_data));
+	struct declaration_data *data = (struct declaration_data *)xmalloc(sizeof(struct declaration_data));
 	if (!data) {
 		return SELINT_OUT_OF_MEM;
 	}
@@ -122,7 +123,7 @@ enum selint_error insert_declaration(struct policy_node **cur,
 	memset(data, 0, sizeof(struct declaration_data));
 
 	data->flavor = flavor;
-	data->name = strdup(name);
+	data->name = xstrdup(name);
 	data->attrs = attrs;
 
 	union node_data nd;
@@ -163,7 +164,7 @@ enum selint_error insert_aliases(struct policy_node **cur,
 			insert_into_decl_map(alias->string, mn, flavor);
 		}
 		union node_data nd;
-		nd.str = strdup(alias->string);
+		nd.str = xstrdup(alias->string);
 		enum selint_error ret = insert_policy_node_child(*cur,
 		                                                 NODE_ALIAS,
 		                                                 nd,
@@ -185,7 +186,7 @@ enum selint_error insert_type_alias(struct policy_node **cur, const char *type,
 
 	union node_data nd;
 
-	nd.str = strdup(type);
+	nd.str = xstrdup(type);
 	enum selint_error ret = insert_policy_node_next(*cur,
 	                                                NODE_TYPE_ALIAS,
 	                                                nd,
@@ -206,7 +207,7 @@ enum selint_error insert_av_rule(struct policy_node **cur,
                                  struct string_list *perms, unsigned int lineno)
 {
 
-	struct av_rule_data *av_data = malloc(sizeof(struct av_rule_data));
+	struct av_rule_data *av_data = xmalloc(sizeof(struct av_rule_data));
 
 	av_data->flavor = flavor;
 	av_data->sources = sources;
@@ -246,13 +247,13 @@ enum selint_error insert_xperm_av_rule(struct policy_node **cur,
                                        unsigned int lineno)
 {
 
-	struct xav_rule_data *xav_data = malloc(sizeof(struct xav_rule_data));
+	struct xav_rule_data *xav_data = xmalloc(sizeof(struct xav_rule_data));
 
 	xav_data->flavor = flavor;
 	xav_data->sources = sources;
 	xav_data->targets = targets;
 	xav_data->object_classes = object_classes;
-	xav_data->operation = strdup(operation);
+	xav_data->operation = xstrdup(operation);
 	xav_data->perms = perms;
 
 	union node_data nd;
@@ -277,7 +278,7 @@ enum selint_error insert_role_allow(struct policy_node **cur,
                                     struct string_list *from_roles,
                                     struct string_list *to_roles, unsigned int lineno)
 {
-	struct role_allow_data *ra_data = malloc(sizeof(struct role_allow_data));
+	struct role_allow_data *ra_data = xmalloc(sizeof(struct role_allow_data));
 
 	ra_data->from = from_roles;
 	ra_data->to = to_roles;
@@ -312,9 +313,9 @@ enum selint_error insert_role_types(struct policy_node **cur, const char *role,
 		}
 	}
 
-	struct role_types_data *rtyp_data = (struct role_types_data *)malloc(sizeof(struct role_types_data));
+	struct role_types_data *rtyp_data = (struct role_types_data *)xmalloc(sizeof(struct role_types_data));
 
-	rtyp_data->role = strdup(role);
+	rtyp_data->role = xstrdup(role);
 	rtyp_data->types = types;
 
 	union node_data nd;
@@ -341,14 +342,14 @@ enum selint_error insert_type_transition(struct policy_node **cur,
 {
 
 	struct type_transition_data *tt_data =
-		malloc(sizeof(struct type_transition_data));
+		xmalloc(sizeof(struct type_transition_data));
 
 	tt_data->sources = sources;
 	tt_data->targets = targets;
 	tt_data->object_classes = object_classes;
-	tt_data->default_type = strdup(default_type);
+	tt_data->default_type = xstrdup(default_type);
 	if (name) {
-		tt_data->name = strdup(name);
+		tt_data->name = xstrdup(name);
 	} else {
 		tt_data->name = NULL;
 	}
@@ -385,12 +386,12 @@ enum selint_error insert_role_transition(struct policy_node **cur,
                                          unsigned int lineno)
 {
 	struct role_transition_data *rt_data =
-	        malloc(sizeof(struct role_transition_data));
+	        xmalloc(sizeof(struct role_transition_data));
 
 	rt_data->sources = sources;
 	rt_data->targets = targets;
 	rt_data->object_classes = object_classes;
-	rt_data->default_role = strdup(default_role);
+	rt_data->default_role = xstrdup(default_role);
 
 	union node_data nd;
 	nd.rt_data = rt_data;
@@ -433,9 +434,9 @@ enum selint_error insert_interface_call(struct policy_node **cur, const char *if
                                         struct string_list *args,
                                         unsigned int lineno)
 {
-	struct if_call_data *if_data = malloc(sizeof(struct if_call_data));
+	struct if_call_data *if_data = xmalloc(sizeof(struct if_call_data));
 
-	if_data->name = strdup(if_name);
+	if_data->name = xstrdup(if_name);
 	if_data->args = args;
 
 	const char *template_name = get_name_if_in_template(*cur);
@@ -479,7 +480,7 @@ enum selint_error insert_permissive_statement(struct policy_node **cur,
 {
 	union node_data nd;
 
-	nd.str = strdup(domain);
+	nd.str = xstrdup(domain);
 	enum selint_error ret = insert_policy_node_next(*cur,
 	                                                NODE_PERMISSIVE,
 	                                                nd,
@@ -611,7 +612,7 @@ enum selint_error end_optional_else(struct policy_node **cur)
 enum selint_error begin_boolean_policy(struct policy_node **cur,
                                        unsigned int lineno)
 {
-	struct cond_declaration_data *cd_data = malloc(sizeof(struct cond_declaration_data));
+	struct cond_declaration_data *cd_data = xmalloc(sizeof(struct cond_declaration_data));
 	cd_data->identifiers = NULL;;
 
 	union node_data nd;
@@ -629,7 +630,7 @@ enum selint_error end_boolean_policy(struct policy_node **cur)
 enum selint_error begin_tunable_policy(struct policy_node **cur,
                                        unsigned int lineno)
 {
-	struct cond_declaration_data *cd_data = malloc(sizeof(struct cond_declaration_data));
+	struct cond_declaration_data *cd_data = xmalloc(sizeof(struct cond_declaration_data));
 	cd_data->identifiers = NULL;;
 
 	union node_data nd;
@@ -662,7 +663,7 @@ enum selint_error begin_interface_def(struct policy_node **cur,
 	insert_into_ifs_map(name, get_current_module_name());
 
 	union node_data nd;
-	nd.str = strdup(name);
+	nd.str = xstrdup(name);
 
 	return begin_block(cur, flavor, nd, lineno);
 }
@@ -680,7 +681,7 @@ enum selint_error end_interface_def(struct policy_node **cur)
 enum selint_error begin_gen_require(struct policy_node **cur,
                                     unsigned int lineno)
 {
-	struct gen_require_data *data = (struct gen_require_data *)malloc(sizeof(struct gen_require_data));
+	struct gen_require_data *data = (struct gen_require_data *)xmalloc(sizeof(struct gen_require_data));
 	union node_data nd;
 	nd.gr_data = data;
 	return begin_block(cur, NODE_GEN_REQ, nd, lineno);
@@ -761,7 +762,7 @@ enum selint_error save_command(struct policy_node *cur, const char *comm)
 	}
 	comm += strlen("selint-");
 	if (0 == strncmp("disable:", comm, 8)) {
-		cur->exceptions = strdup(comm + strlen("disable:"));
+		cur->exceptions = xstrdup(comm + strlen("disable:"));
 	} else {
 		return SELINT_PARSE_ERROR;
 	}
@@ -801,14 +802,14 @@ static enum node_flavor attr_to_node_flavor(enum attr_flavor flavor)
 
 static enum selint_error insert_attribute(struct policy_node **cur, enum attr_flavor flavor, const char *type, struct string_list *attrs, unsigned int lineno)
 {
-	struct attribute_data *data = calloc(1, sizeof(struct attribute_data));
+	struct attribute_data *data = xcalloc(1, sizeof(struct attribute_data));
 	if (!data) {
 		return SELINT_OUT_OF_MEM;
 	}
 	union node_data nd;
 	nd.at_data = data;
 
-	data->type = strdup(type);
+	data->type = xstrdup(type);
 	data->attrs = attrs;
 	data->flavor = flavor;
 

--- a/src/perm_macro.c
+++ b/src/perm_macro.c
@@ -24,6 +24,7 @@
 #include "color.h"
 #include "maps.h"
 #include "util.h"
+#include "xalloc.h"
 
 typedef uint32_t mask_t;
 
@@ -200,8 +201,8 @@ static struct string_builder *sb_create(size_t init_cap)
 		init_cap = 32;
 	}
 
-	struct string_builder *ret = malloc(sizeof(struct string_builder));
-	ret->mem = malloc(sizeof(char) * init_cap);
+	struct string_builder *ret = xmalloc(sizeof(struct string_builder));
+	ret->mem = xmalloc(sizeof(char) * init_cap);
 	ret->mem[0] = '\0';
 	ret->len = 0;
 	ret->cap = init_cap;
@@ -222,7 +223,7 @@ static void sb_destroy(struct string_builder *sb)
 static void sb_append_strn(struct string_builder *sb, const char *str, size_t len)
 {
 	while (sb->len + len + 1 > sb->cap) {
-		sb->mem = realloc(sb->mem, 2 * sb->cap);
+		sb->mem = xrealloc(sb->mem, 2 * sb->cap);
 		sb->cap = 2 * sb->cap;
 	}
 
@@ -352,8 +353,8 @@ static void load_permission_macro(const char *name, const struct string_list *pe
 		return;
 	}
 
-	struct perm_macro *tmp = malloc(sizeof(struct perm_macro));
-	tmp->name = strdup(name);
+	struct perm_macro *tmp = xmalloc(sizeof(struct perm_macro));
+	tmp->name = xstrdup(name);
 	tmp->mask_raw = mask_raw;
 
 	// first entry
@@ -495,7 +496,7 @@ char *permmacro_check(const char *class, const struct string_list *permissions)
 	char *perms_matched = permission_strings_matched_str(permissions, best_mask_raw & mask_raw);
 #define MSG_STR "Suggesting permission macro: %s (replacing %s, would add %s)"
 	size_t len = (size_t)snprintf(NULL, 0, MSG_STR, best_name, perms_matched, perms_added);
-	char *ret = malloc(len + 1);
+	char *ret = xmalloc(len + 1);
 	snprintf(ret, len + 1, MSG_STR, best_name, perms_matched, perms_added);
 #undef MSG_STR
 	free(perms_matched);

--- a/src/runner.c
+++ b/src/runner.c
@@ -28,13 +28,14 @@
 #include "parse.h"
 #include "util.h"
 #include "startup.h"
+#include "xalloc.h"
 
 #define CHECK_ENABLED(cid) is_check_enabled(cid, config_enabled_checks, config_disabled_checks, cl_enabled_checks, cl_disabled_checks, only_enabled)
 
 struct policy_node *parse_one_file(const char *filename, enum node_flavor flavor)
 {
 
-	char *copy = strdup(filename);
+	char *copy = xstrdup(filename);
 	char *mod_name = basename(copy);
 	mod_name[strlen(mod_name) - 3] = '\0'; // Remove suffix
 	set_current_module_name(mod_name);
@@ -98,7 +99,7 @@ struct checks *register_checks(char level,
                                int only_enabled)
 {
 
-	struct checks *ck = malloc(sizeof(struct checks));
+	struct checks *ck = xmalloc(sizeof(struct checks));
 
 	memset(ck, 0, sizeof(struct checks));
 
@@ -400,11 +401,11 @@ enum selint_error run_all_checks(struct checks *ck, enum file_flavor flavor,
 
 	while (file) {
 		{
-			char *copy = strdup(file->file->filename);
-			data.filename = strdup(basename(copy));
+			char *copy = xstrdup(file->file->filename);
+			data.filename = xstrdup(basename(copy));
 			free(copy);
 		}
-		data.mod_name = strdup(data.filename);
+		data.mod_name = xstrdup(data.filename);
 		data.config_check_data = ccd;
 
 		char *suffix_ptr = strrchr(data.mod_name, '.');
@@ -453,7 +454,7 @@ enum selint_error run_analysis(struct checks *ck,
 	}
 
 	// Make temporary joined list to mark ALL transform interfaces
-	struct policy_file_list *all_if_files = calloc(1, sizeof(struct policy_file_list));
+	struct policy_file_list *all_if_files = xcalloc(1, sizeof(struct policy_file_list));
 	if (if_files->tail) {
 		// Only concatenate if if_files contains files
 		all_if_files->head = if_files->head;

--- a/src/startup.c
+++ b/src/startup.c
@@ -27,6 +27,7 @@
 #include "tree.h"
 #include "util.h"
 #include "parse.h"
+#include "xalloc.h"
 
 enum selint_error load_access_vectors_kernel(const char *av_path)
 {
@@ -235,7 +236,7 @@ IGNORE_CONST_DISCARD_END;
 			file_list_push_back(context_files,
 			                    make_policy_file(file->fts_path,
 			                                     NULL));
-			char *mod_name = strdup(file->fts_name);
+			char *mod_name = xstrdup(file->fts_name);
 			mod_name[file->fts_namelen - 3] = '\0';
 			insert_into_mod_layers_map(mod_name, file->fts_parent->fts_name);
 			free(mod_name);

--- a/src/string_list.c
+++ b/src/string_list.c
@@ -19,6 +19,8 @@
 #include <string.h>
 
 #include "string_list.h"
+#include "xalloc.h"
+
 int str_in_sl(const char *str, const struct string_list *sl)
 {
 
@@ -40,16 +42,16 @@ struct string_list *copy_string_list(const struct string_list *sl)
 	if (!sl) {
 		return NULL;
 	}
-	struct string_list *ret = malloc(sizeof(struct string_list));
+	struct string_list *ret = xmalloc(sizeof(struct string_list));
 	struct string_list *cur = ret;
 
 	while (sl) {
-		cur->string = strdup(sl->string);
+		cur->string = xstrdup(sl->string);
 		cur->has_incorrect_space = sl->has_incorrect_space;
 		cur->arg_start = sl->arg_start;
 
 		if (sl->next) {
-			cur->next = malloc(sizeof(struct string_list));
+			cur->next = xmalloc(sizeof(struct string_list));
 		} else {
 			cur->next = NULL;
 		}
@@ -61,8 +63,8 @@ struct string_list *copy_string_list(const struct string_list *sl)
 
 struct string_list *sl_from_str(const char *string)
 {
-	struct string_list *ret = malloc(sizeof(struct string_list));
-	ret->string = strdup(string);
+	struct string_list *ret = xmalloc(sizeof(struct string_list));
+	ret->string = xstrdup(string);
 	ret->next = NULL;
 	ret->has_incorrect_space = 0;
 	ret->arg_start = 0;
@@ -72,8 +74,8 @@ struct string_list *sl_from_str(const char *string)
 
 struct string_list *sl_from_strn(const char *string, size_t len)
 {
-	struct string_list *ret = malloc(sizeof(struct string_list));
-	ret->string = strndup(string, len);
+	struct string_list *ret = xmalloc(sizeof(struct string_list));
+	ret->string = xstrndup(string, len);
 	ret->next = NULL;
 	ret->has_incorrect_space = 0;
 	ret->arg_start = 0;
@@ -83,7 +85,7 @@ struct string_list *sl_from_strn(const char *string, size_t len)
 
 struct string_list *sl_from_str_consume(char *string)
 {
-	struct string_list *ret = malloc(sizeof(struct string_list));
+	struct string_list *ret = xmalloc(sizeof(struct string_list));
 	ret->string = string;
 	ret->next = NULL;
 	ret->has_incorrect_space = 0;

--- a/src/te_checks.c
+++ b/src/te_checks.c
@@ -24,6 +24,7 @@
 #include "ordering.h"
 #include "util.h"
 #include "perm_macro.h"
+#include "xalloc.h"
 
 struct check_result *check_excluding_av_rule(__attribute__((unused)) const struct check_data *data,
                                              const struct policy_node *node)
@@ -708,7 +709,7 @@ struct check_result *check_module_file_name_mismatch(const struct check_data
 static bool starts_with_module_prefix(const char *name)
 {
 	for (const char *prefix = strchr(name, '_'); prefix; prefix = strchr(prefix + 1, '_')) {
-		char *search_mod = strndup(name, (size_t)(prefix - name));
+		char *search_mod = xstrndup(name, (size_t)(prefix - name));
 		if (look_up_in_mods_map(search_mod)) {
 			free(search_mod);
 			return true;

--- a/src/template.c
+++ b/src/template.c
@@ -22,6 +22,7 @@
 
 #include "template.h"
 #include "maps.h"
+#include "xalloc.h"
 
 char *replace_m4(const char *orig, const struct string_list *args)
 {
@@ -34,7 +35,7 @@ char *replace_m4(const char *orig, const struct string_list *args)
 	}
 	// len_to_malloc is now overestimated, because the length of the original
 	// arguments wasn't subtracted and not all args are necessarily substituted
-	char *ret = malloc(len_to_malloc);
+	char *ret = xmalloc(len_to_malloc);
 	*ret = '\0';            // If the string is only a substitution that there is no argument for, we need to be terminated
 	const char *orig_pos = orig;
 	char *ret_pos = ret;
@@ -75,7 +76,7 @@ char *replace_m4(const char *orig, const struct string_list *args)
 struct string_list *replace_m4_list(const struct string_list *replace_with,
                                     const struct string_list *replace_from)
 {
-	struct string_list *ret = calloc(1, sizeof(struct string_list));
+	struct string_list *ret = xcalloc(1, sizeof(struct string_list));
 	struct string_list *cur = ret;
 
 	cur->string = replace_m4(replace_from->string, replace_with);
@@ -83,7 +84,7 @@ struct string_list *replace_m4_list(const struct string_list *replace_with,
 	replace_from = replace_from->next;
 
 	while (replace_from) {
-		cur->next = calloc(1, sizeof(struct string_list));
+		cur->next = xcalloc(1, sizeof(struct string_list));
 		cur = cur->next;
 		cur->string = replace_m4(replace_from->string, replace_with);
 		cur->next = NULL;
@@ -108,8 +109,8 @@ enum selint_error add_template_declarations(const char *template_name,
 		cur = cur->next;
 	}
 
-	cur = calloc(1, sizeof(struct string_list));
-	cur->string = strdup(template_name);
+	cur = xcalloc(1, sizeof(struct string_list));
+	cur->string = xstrdup(template_name);
 	cur->next = parent_temp_names;
 
 	const struct if_call_list *calls =

--- a/src/tree.c
+++ b/src/tree.c
@@ -20,6 +20,7 @@
 #include "tree.h"
 #include "maps.h"
 #include "selint_error.h"
+#include "xalloc.h"
 
 enum selint_error insert_policy_node_child(struct policy_node *parent,
                                            enum node_flavor flavor,
@@ -30,7 +31,7 @@ enum selint_error insert_policy_node_child(struct policy_node *parent,
 		return SELINT_BAD_ARG;
 	}
 
-	struct policy_node *to_insert = malloc(sizeof(struct policy_node));
+	struct policy_node *to_insert = xmalloc(sizeof(struct policy_node));
 	if (!to_insert) {
 		return SELINT_OUT_OF_MEM;
 	}
@@ -71,7 +72,7 @@ enum selint_error insert_policy_node_next(struct policy_node *prev,
 		return SELINT_BAD_ARG;
 	}
 
-	struct policy_node *to_insert = malloc(sizeof(struct policy_node));
+	struct policy_node *to_insert = xmalloc(sizeof(struct policy_node));
 	if (!to_insert) {
 		return SELINT_OUT_OF_MEM;
 	}

--- a/src/xalloc.h
+++ b/src/xalloc.h
@@ -1,0 +1,87 @@
+/*
+* Copyright 2022 The SELint Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef XALLOC_H
+#define XALLOC_H
+
+#include <stdio.h>
+#include <sysexits.h>
+
+#define oom_failure()                                             \
+	do {                                                      \
+		fprintf(stderr,                                   \
+			"Failed to allocate memory [%s():%d]\n",  \
+			__func__,                                 \
+			__LINE__);                                \
+		exit(EX_OSERR);                                   \
+	} while(0)
+
+/*********************************************
+* Checked malloc wrapper.
+*********************************************/
+#define xmalloc(size) ({            \
+	void *ret_ = malloc(size);  \
+	if (!ret_) {                \
+		oom_failure();      \
+	}                           \
+	ret_;                       \
+})
+
+/*********************************************
+* Checked calloc wrapper.
+*********************************************/
+#define xcalloc(nmemb, size) ({            \
+	void *ret_ = calloc(nmemb, size);  \
+	if (!ret_) {                       \
+		oom_failure();             \
+	}                                  \
+	ret_;                              \
+})
+
+/*********************************************
+* Checked realloc wrapper.
+*********************************************/
+#define xrealloc(ptr, size) ({            \
+	void *ret_ = realloc(ptr, size);  \
+	if (!ret_) {                      \
+		oom_failure();            \
+	}                                 \
+	ret_;                             \
+})
+
+/*********************************************
+* Checked strdup wrapper.
+*********************************************/
+#define xstrdup(str) ({            \
+	void *ret_ = strdup(str);  \
+	if (!ret_) {               \
+		oom_failure();     \
+	}                          \
+	ret_;                      \
+})
+
+/*********************************************
+* Checked strndup wrapper.
+*********************************************/
+#define xstrndup(str, size) ({            \
+	void *ret_ = strndup(str, size);  \
+	if (!ret_) {                      \
+		oom_failure();            \
+	}                                 \
+	ret_;                             \
+})
+
+#endif /* XALLOC_H */


### PR DESCRIPTION
Check all allocations for failures (OOM), not only to avoid mostly
harmless NULL-dereferences, but also UB and memory corruption caused by
optimizations.

See also: https://pvs-studio.com/en/blog/posts/cpp/0938/

Occurrences:
    grep -REw "(malloc|calloc|strdup|strndup|realloc|reallocarray)" src/